### PR TITLE
Fix clicking the calendar button would submit the form

### DIFF
--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -96,6 +96,7 @@ export default class DatePicker extends Component {
           className="react-date-picker__button__icon"
           onClick={this.toggleCalendar}
           onFocus={this.stopPropagation}
+          type="button"
         >
           <svg xmlns="http://www.w3.org/2000/svg" width="19" height="19" viewBox="0 0 19 19">
             <g stroke="black" strokeWidth="2">


### PR DESCRIPTION
If the `type` attribute of a button is omitted, it defaults to `submit`, this would trigger the form submit event if the datepicker was placed in a form.

This forces the type to `button` so it doesn't do that behaviour anymore.

Please publish a patch with this issue resolved :)