### PR TITLE
Fix Safari and Firefox issue on Mac caused by blur and focus

### DIFF
--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -17,12 +17,30 @@ export default class DatePicker extends Component {
     isOpen: this.props.isOpen,
   }
 
+  componentDidMount() {
+    document.addEventListener('mousedown', this.handleClickOutside);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('mousedown', this.handleClickOutside);
+  }
+
   componentWillReceiveProps(nextProps) {
     const { props } = this;
 
     if (nextProps.isOpen !== props.isOpen) {
       this.setState({ isOpen: nextProps.isOpen });
     }
+  }
+
+  handleClickOutside = (event) => {
+    if (this.wrapperRef && !this.wrapperRef.contains(event.target)) {
+      this.closeCalendar();
+    }
+  }
+
+  setWrapperRef = (node) => {
+    this.wrapperRef = node;
   }
 
   openCalendar = () => {
@@ -49,26 +67,7 @@ export default class DatePicker extends Component {
   }
 
   onFocus = () => {
-    this.blurRequested = false;
-
     this.openCalendar();
-  }
-
-  onBlur = () => {
-    this.blurRequested = true;
-
-    /**
-     * We wait 100 milliseconds in case focus event was triggered right
-     * after blur event - this is a situation when the user jumps from
-     * one input field to another.
-     */
-    setTimeout(() => {
-      if (this.blurRequested) {
-        this.closeCalendar();
-
-        this.blurRequested = false;
-      }
-    }, 100);
   }
 
   stopPropagation = event => event.stopPropagation()
@@ -173,7 +172,7 @@ export default class DatePicker extends Component {
           this.props.className,
         )}
         onFocus={this.onFocus}
-        onBlur={this.onBlur}
+        ref={this.setWrapperRef}
       >
         {this.renderInput()}
         {this.renderCalendar()}


### PR DESCRIPTION
As discussed in Issue https://github.com/wojtekmaj/react-date-picker/issues/15, in Safari 11.0.1 & Firefox 56.0.2 for Mac the calendar was losing focus when a user clicked on next / previous arrows and in other areas of the expanded calendar.

I have removed the current `blurRequested` functionality that uses `setTimeout` and instead blurred when the user clicks outside of the DatePicker.