### PR TITLE
Change click event to mousedown to prevent rerender before checking click target

### DIFF
--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -18,11 +18,11 @@ export default class DatePicker extends Component {
   }
 
   componentDidMount() {
-    document.addEventListener('click', this.onClick);
+    document.addEventListener('mousedown', this.onClick);
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.onClick);
+    document.removeEventListener('mousedown', this.onClick);
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
Issue https://github.com/wojtekmaj/react-date-picker/issues/21 - when clicking a drilldown calendar tile (i.e. from year to month, decade to year, or century to decade), calendar closes.

There was a click listener that was trying to find `event.target` while the calendar was re-rendering and therefore the `ref` was undefined and so `this.closeCalendar()` was being called.

Changing to check the ref on `mousedown` should have fixed this issue.