### PR TITLE
Check if the element would be offscreen before moving it (#52)

### DIFF
--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -151,7 +151,9 @@ export default class DatePicker extends PureComponent {
 
           const collisions = detectElementOverflow(ref, document.body);
 
-          if (collisions.collidedBottom) {
+          const wouldBeOffscreen = document.body.getBoundingClientRect().top < ref.getBoundingClientRect().height
+
+          if (collisions.collidedBottom && !wouldBeOffscreen) {
             ref.classList.add(`${className}--above-label`);
           }
         }}


### PR DESCRIPTION
If the field is close to the top of the page, moving the selector
above the input can cause the field to go off the page. This change
prevents the selector from going off the page.

Fixes issue #52