### PR TITLE
Adding 'range' to returnValue propTypes

### DIFF
--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -240,7 +240,7 @@ DatePicker.propTypes = {
   disabled: PropTypes.bool,
   isOpen: PropTypes.bool,
   name: PropTypes.string,
-  returnValue: PropTypes.oneOf(['start', 'end']),
+  returnValue: PropTypes.oneOf(['start', 'end', 'range']),
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
 };


### PR DESCRIPTION
Range was missing in propTypes definition, but is documented and works.

Thanks for a great package!