### PR TITLE
Improved handling of leading zeros, length limit and UX

### DIFF
--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -44,8 +44,8 @@ export default class DayInput extends PureComponent {
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required, showLeadingZeros,
     } = this.props;
-    value = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : "";
-    if (showLeadingZeros && value.length === 1) value = "0" + value;
+    let v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : "";
+    if (showLeadingZeros && v.length === 1) v = "0" + v;
     const name = 'day';
     
     return [
@@ -76,7 +76,7 @@ export default class DayInput extends PureComponent {
         }}
         required={required}
         type="number"
-        value={value}
+        value={v}
       />,
     ];
   }

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -76,7 +76,7 @@ export default class DayInput extends PureComponent {
         }}
         required={required}
         type="number"
-        value={value !== null ? value : ''}
+        value={value}
       />,
     ];
   }

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -44,8 +44,8 @@ export default class DayInput extends PureComponent {
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required, showLeadingZeros,
     } = this.props;
-    let v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : "";
-    if (showLeadingZeros && v.length === 1) v = "0" + v;
+    let v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : '';
+    if (showLeadingZeros && v.length === 1) v = '0' + v;
     const name = 'day';
     
     return [
@@ -54,7 +54,6 @@ export default class DayInput extends PureComponent {
         className={mergeClassNames(
           `${className}__input`,
           `${className}__day`,
-          hasLeadingZero && `${className}__input--hasLeadingZero`,
         )}
         disabled={disabled}
         name={name}

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -44,12 +44,11 @@ export default class DayInput extends PureComponent {
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required, showLeadingZeros,
     } = this.props;
-
+    value = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : "";
+    if (showLeadingZeros && value.length === 1) value = "0" + value;
     const name = 'day';
-    const hasLeadingZero = showLeadingZeros && value !== null && value < 10;
-
+    
     return [
-      (hasLeadingZero && <span key="leadingZero" className={`${className}__leadingZero`}>0</span>),
       <input
         key="day"
         className={mergeClassNames(


### PR DESCRIPTION
Please consider these changes. I don't see disadvantages, but maybe you see some. 

Advantages:
- no extra span element for leading zeros (which is difficult to keep aligned to the rest) and makes selection weird
- keep expected behavior for `showLeadingZeros`
- ensures the user does not type more than 2 digits (which is always invalid day)
- the user can type a sequence of numbers, just the last two will be used (this feels like the most natural behavior for this kind of field to me)

I only made this changes to the DayInput, but I could also extend to the other inputs if we agree this makes sense.