### PR TITLE
Handle leading zeros and improve UX with default input fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "copy-styles": "node ./copy-styles.js",
     "copy-types": "node ./copy-types.js",
     "prepublishOnly": "yarn run clean && yarn run build",
+    "prepare": "yarn run clean && yarn run build",
     "test": "yarn run test-eslint && yarn run test-jest",
     "test-eslint": "eslint src/ test/ --ext .jsx,.js",
     "test-jest": "jest",

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -273,6 +273,48 @@ export default class DateInput extends PureComponent {
 
   onKeyDown = (event) => {
     switch (event.key) {
+			case 'ArrowUp': {
+				event.preventDefault();
+				const key = event.target.name;
+				const { value } = this.state;
+				const nextValue = new Date(value);
+				if (key === 'day') {
+				  nextValue.setDate(nextValue.getDate() + 1);
+        }
+        else if (key === 'month') {
+					nextValue.setMonth(nextValue.getMonth() + 1);
+        }
+				else if (key === 'year') {
+					nextValue.setFullYear(nextValue.getFullYear() + 1);
+				}
+        this.onChangeKeyEvent(nextValue);
+				break;
+			}
+			case 'ArrowDown': {
+				event.preventDefault();
+				const key = event.target.name;
+				const { value } = this.state;
+				const nextValue = new Date(value);
+				if (key === 'day') {
+					nextValue.setDate(nextValue.getDate() - 1);
+				}
+				else if (key === 'month') {
+					nextValue.setMonth(nextValue.getMonth() - 1);
+				}
+				else if (key === 'year') {
+					nextValue.setFullYear(nextValue.getFullYear() - 1);
+				}
+				this.onChangeKeyEvent(nextValue);
+				break;
+			}
+			case 'ArrowDown': {
+				event.preventDefault();
+
+				const input = event.target;
+				const previousInput = findPreviousInput(input);
+				focus(previousInput);
+				break;
+			}
       case 'ArrowLeft': {
         event.preventDefault();
 
@@ -333,6 +375,16 @@ export default class DateInput extends PureComponent {
     onChange(processedValue, false);
   }
 
+  onChangeKeyEvent = (proposedValue) => {
+		const { onChange } = this.props;
+
+		if (!onChange) {
+			return;
+		}
+		const processedValue = this.getProcessedValue(proposedValue);
+		return onChange(processedValue, false);
+  }
+
   /**
    * Called after internal onChange. Checks input validity. If all fields are valid,
    * calls props.onChange.
@@ -345,20 +397,22 @@ export default class DateInput extends PureComponent {
     }
 
     const formElements = [this.dayInput, this.monthInput, this.yearInput].filter(Boolean);
+    const activeElement = formElements.find(el => document.activeElement === el);
 
     const values = {};
     formElements.forEach((formElement) => {
       values[formElement.name] = formElement.value;
     });
-
     if (formElements.every(formElement => !formElement.value)) {
       onChange(null, false);
-    } else if (
-      formElements.every(formElement => formElement.value && formElement.checkValidity())
-    ) {
+    } else if (Date.parse(`${values.year}-${values.month}-${values.day}`)) {
       const proposedValue = new Date(values.year, (values.month || 1) - 1, values.day || 1);
       const processedValue = this.getProcessedValue(proposedValue);
-      onChange(processedValue, false);
+			formElements.forEach(el => el.setCustomValidity(''));
+			onChange(processedValue, false);
+    }
+    else if (activeElement) {
+      activeElement.setCustomValidity('Invalid date');
     }
   }
 

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -271,50 +271,46 @@ export default class DateInput extends PureComponent {
     return getValueType(maxDetail);
   }
 
+  isValidDate = (date) => {
+    return (date >= (this.props.minDate || defaultMinDate)) && (date <= (this.props.maxDate || defaultMaxDate));
+  }
+
   onKeyDown = (event) => {
     switch (event.key) {
-			case 'ArrowUp': {
-				event.preventDefault();
-				const key = event.target.name;
-				const { value } = this.state;
-				const nextValue = new Date(value);
-				if (key === 'day') {
-				  nextValue.setDate(nextValue.getDate() + 1);
+      case 'ArrowUp': {
+        event.preventDefault();
+        const key = event.target.name;
+        const { value } = this.state;
+        const nextValue = new Date(value);
+        if (key === 'day') {
+          nextValue.setDate(nextValue.getDate() + 1);
         }
         else if (key === 'month') {
-					nextValue.setMonth(nextValue.getMonth() + 1);
+          nextValue.setMonth(nextValue.getMonth() + 1);
         }
-				else if (key === 'year') {
-					nextValue.setFullYear(nextValue.getFullYear() + 1);
-				}
+        else if (key === 'year') {
+          nextValue.setFullYear(nextValue.getFullYear() + 1);
+        }
         this.onChangeKeyEvent(nextValue);
-				break;
-			}
-			case 'ArrowDown': {
-				event.preventDefault();
-				const key = event.target.name;
-				const { value } = this.state;
-				const nextValue = new Date(value);
-				if (key === 'day') {
-					nextValue.setDate(nextValue.getDate() - 1);
-				}
-				else if (key === 'month') {
-					nextValue.setMonth(nextValue.getMonth() - 1);
-				}
-				else if (key === 'year') {
-					nextValue.setFullYear(nextValue.getFullYear() - 1);
-				}
-				this.onChangeKeyEvent(nextValue);
-				break;
-			}
-			case 'ArrowDown': {
-				event.preventDefault();
-
-				const input = event.target;
-				const previousInput = findPreviousInput(input);
-				focus(previousInput);
-				break;
-			}
+        break;
+      }
+      case 'ArrowDown': {
+        event.preventDefault();
+        const key = event.target.name;
+        const { value } = this.state;
+        const nextValue = new Date(value);
+        if (key === 'day') {
+          nextValue.setDate(nextValue.getDate() - 1);
+        }
+        else if (key === 'month') {
+          nextValue.setMonth(nextValue.getMonth() - 1);
+        }
+        else if (key === 'year') {
+          nextValue.setFullYear(nextValue.getFullYear() - 1);
+        }
+        this.onChangeKeyEvent(nextValue);
+        break;
+      }
       case 'ArrowLeft': {
         event.preventDefault();
 
@@ -376,13 +372,13 @@ export default class DateInput extends PureComponent {
   }
 
   onChangeKeyEvent = (proposedValue) => {
-		const { onChange } = this.props;
+    const { onChange } = this.props;
 
-		if (!onChange) {
-			return;
-		}
-		const processedValue = this.getProcessedValue(proposedValue);
-		return onChange(processedValue, false);
+    if (!onChange) {
+      return;
+    }
+    const processedValue = this.getProcessedValue(proposedValue);
+    return onChange(processedValue, false);
   }
 
   /**
@@ -407,9 +403,14 @@ export default class DateInput extends PureComponent {
       onChange(null, false);
     } else if (Date.parse(`${values.year}-${values.month}-${values.day}`)) {
       const proposedValue = new Date(values.year, (values.month || 1) - 1, values.day || 1);
-      const processedValue = this.getProcessedValue(proposedValue);
-			formElements.forEach(el => el.setCustomValidity(''));
-			onChange(processedValue, false);
+      if (this.isValidDate(proposedValue)) {
+        const processedValue = this.getProcessedValue(proposedValue);
+        formElements.forEach(el => el.setCustomValidity(''));
+        onChange(processedValue, false);
+      }
+      else {
+        formElements.forEach(el => el.setCustomValidity('Invalid range'));
+      }
     }
     else if (activeElement) {
       activeElement.setCustomValidity('Invalid date');
@@ -424,17 +425,15 @@ export default class DateInput extends PureComponent {
       return null;
     }
 
-    const { day: value, month, year } = this.state;
+    const { day: value } = this.state;
 
     return (
       <DayInput
         key="day"
         {...this.commonInputProps}
         maxDetail={maxDetail}
-        month={month}
         showLeadingZeros={showLeadingZeros}
         value={value}
-        year={year}
       />
     );
   }
@@ -447,7 +446,7 @@ export default class DateInput extends PureComponent {
       return null;
     }
 
-    const { month: value, year } = this.state;
+    const { month: value } = this.state;
 
     return (
       <MonthInput
@@ -456,7 +455,6 @@ export default class DateInput extends PureComponent {
         maxDetail={maxDetail}
         showLeadingZeros={showLeadingZeros}
         value={value}
-        year={year}
       />
     );
   }

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -2,45 +2,13 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'merge-class-names';
 
-import {
-  getDay,
-  getDaysInMonth,
-  getMonth,
-  getYear,
-} from '../shared/dates';
 import { isMaxDate, isMinDate } from '../shared/propTypes';
-import { min, max, updateInputWidth } from '../shared/utils';
+import { updateInputWidth } from '../shared/utils';
 
 const select = element => element && element.select();
 
 export default class DayInput extends PureComponent {
-  get currentMonthMaxDays() {
-    const { year, month } = this.props;
-
-    if (!month) {
-      return 31;
-    }
-
-    return getDaysInMonth(new Date(year, month - 1, 1));
-  }
-
-  get maxDay() {
-    const { maxDate, month, year } = this.props;
-    return min(
-      this.currentMonthMaxDays,
-      maxDate && year === getYear(maxDate) && month === getMonth(maxDate) && getDay(maxDate),
-    );
-  }
-
-  get minDay() {
-    const { minDate, month, year } = this.props;
-    return max(
-      1, minDate && year === getYear(minDate) && month === getMonth(minDate) && getDay(minDate),
-    );
-  }
-
   render() {
-    const { maxDay, minDay } = this;
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required, showLeadingZeros,
     } = this.props;
@@ -57,8 +25,6 @@ export default class DayInput extends PureComponent {
         )}
         disabled={disabled}
         name={name}
-        max={maxDay}
-        min={minDay}
         onChange={onChange}
         onFocus={event => select(event.target)}
         onKeyDown={onKeyDown}
@@ -84,13 +50,9 @@ DayInput.propTypes = {
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
-  maxDate: isMaxDate,
-  minDate: isMinDate,
-  month: PropTypes.number,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
   value: PropTypes.number,
-  year: PropTypes.number,
 };

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -44,18 +44,16 @@ export default class DayInput extends PureComponent {
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required, showLeadingZeros,
     } = this.props;
-
+    let v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : '';
+    if (showLeadingZeros && v.length === 1) v = `0${v}`;
     const name = 'day';
-    const hasLeadingZero = showLeadingZeros && value !== null && value < 10;
 
     return [
-      (hasLeadingZero && <span key="leadingZero" className={`${className}__leadingZero`}>0</span>),
       <input
         key="day"
         className={mergeClassNames(
           `${className}__input`,
           `${className}__day`,
-          hasLeadingZero && `${className}__input--hasLeadingZero`,
         )}
         disabled={disabled}
         name={name}
@@ -76,8 +74,7 @@ export default class DayInput extends PureComponent {
           }
         }}
         required={required}
-        type="number"
-        value={value !== null ? value : ''}
+        value={v}
       />,
     ];
   }

--- a/src/DateInput/MonthInput.jsx
+++ b/src/DateInput/MonthInput.jsx
@@ -2,26 +2,11 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'merge-class-names';
 
-import {
-  getMonth,
-  getYear,
-} from '../shared/dates';
-import { isMaxDate, isMinDate } from '../shared/propTypes';
-import { min, max, updateInputWidth } from '../shared/utils';
+import { updateInputWidth } from '../shared/utils';
 
 const select = element => element && element.select();
 
 export default class MonthInput extends PureComponent {
-  get maxMonth() {
-    const { maxDate, year } = this.props;
-    return min(12, maxDate && year === getYear(maxDate) && getMonth(maxDate));
-  }
-
-  get minMonth() {
-    const { minDate, year } = this.props;
-    return max(1, minDate && year === getYear(minDate) && getMonth(minDate));
-  }
-
   render() {
     const { maxMonth, minMonth } = this;
     const {
@@ -29,21 +14,18 @@ export default class MonthInput extends PureComponent {
     } = this.props;
 
     const name = 'month';
-    const hasLeadingZero = showLeadingZeros && value !== null && value < 10;
+    let v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-2) : '';
+    if (showLeadingZeros && v.length === 1) v = `0${v}`;
 
     return [
-      (hasLeadingZero && <span key="leadingZero" className={`${className}__leadingZero`}>0</span>),
       <input
         key="month"
         className={mergeClassNames(
           `${className}__input`,
           `${className}__month`,
-          hasLeadingZero && `${className}__input--hasLeadingZero`,
         )}
         disabled={disabled}
         name={name}
-        max={maxMonth}
-        min={minMonth}
         onChange={onChange}
         onFocus={event => select(event.target)}
         onKeyDown={onKeyDown}
@@ -58,9 +40,8 @@ export default class MonthInput extends PureComponent {
             itemRef(ref, name);
           }
         }}
-        type="number"
         required={required}
-        value={value !== null ? value : ''}
+        value={v}
       />,
     ];
   }
@@ -70,12 +51,9 @@ MonthInput.propTypes = {
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
-  maxDate: isMaxDate,
-  minDate: isMinDate,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
   value: PropTypes.number,
-  year: PropTypes.number,
 };

--- a/src/DateInput/YearInput.jsx
+++ b/src/DateInput/YearInput.jsx
@@ -2,40 +2,16 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import mergeClassNames from 'merge-class-names';
 
-import {
-  getYear,
-} from '../shared/dates';
-import { isMaxDate, isMinDate, isValueType } from '../shared/propTypes';
-import { max, min, updateInputWidth } from '../shared/utils';
+import { updateInputWidth } from '../shared/utils';
 
 const select = element => element && element.select();
 
 export default class YearInput extends PureComponent {
-  get maxYear() {
-    const { maxDate } = this.props;
-    return min(275760, maxDate && getYear(maxDate));
-  }
-
-  get minYear() {
-    const { minDate } = this.props;
-    return max(1000, minDate && getYear(minDate));
-  }
-
-  get yearStep() {
-    const { valueType } = this.props;
-
-    if (valueType === 'century') {
-      return 10;
-    }
-    return 1;
-  }
-
   render() {
-    const { maxYear, minYear, yearStep } = this;
     const {
       className, disabled, itemRef, value, onChange, onKeyDown, required,
     } = this.props;
-
+    const v = parseInt(value, 10) ? parseInt(value, 10).toString().slice(-4) : '';
     const name = 'year';
 
     return (
@@ -46,8 +22,6 @@ export default class YearInput extends PureComponent {
         )}
         disabled={disabled}
         name={name}
-        max={maxYear}
-        min={minYear}
         onChange={onChange}
         onFocus={event => select(event.target)}
         onKeyDown={onKeyDown}
@@ -63,9 +37,7 @@ export default class YearInput extends PureComponent {
           }
         }}
         required={required}
-        step={yearStep}
-        type="number"
-        value={value !== null ? value : ''}
+        value={v}
       />
     );
   }
@@ -75,11 +47,8 @@ YearInput.propTypes = {
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
-  maxDate: isMaxDate,
-  minDate: isMinDate,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   required: PropTypes.bool,
   value: PropTypes.number,
-  valueType: isValueType,
 };


### PR DESCRIPTION
New proposal, using normal input field, instead of `type=number`.
Advantages:
- no need for additional span to handle leading zeros, while supporting all major browsers
- update on ArrowUp/ArrowDown easily handled at parent level ('DateInput`), allowing for infinite date sequences (ie. 12-31-2018 -> focus on day 31 -> ArrowUp -> 01-01-2019)
- validation on `minDate`/`maxDate` also handled in `DateInput`, which simplifies the logic of `DayInput`, MonthInput` and `YearInput` quite a bit

What do you think?