### PR TITLE
Add NPM badge+link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![npm](https://img.shields.io/npm/v/react-date-picker.svg)](https://www.npmjs.com/package/react-date-picker)
 ![downloads](https://img.shields.io/npm/dt/react-date-picker.svg) ![build](https://img.shields.io/travis/wojtekmaj/react-date-picker/master.svg) ![dependencies](https://img.shields.io/david/wojtekmaj/react-date-picker.svg
 ) ![dev dependencies](https://img.shields.io/david/dev/wojtekmaj/react-date-picker.svg
 ) [![tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)


### PR DESCRIPTION
I wanted to get back from the GH repo page to the npm listing; it wasn't immediately obvious if it was possible to do so; I was too lazy to read the README properly so I forked it and added a link. :-)