### PR TITLE
Add default values column in readme; Move "can be" values to examples values column

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,34 +92,34 @@ Displays an input field complete with custom inputs, native input, and a calenda
 
 #### Props
 
-|Prop name|Description|Example values|
-|----|----|----|
-|calendarAriaLabel|Defines the `aria-label` for the calendar button.|`"Toggle clock"`|
-|calendarClassName|Defines class name(s) that will be added along with "react-calendar" to the main React-Calendar `<div>` element.|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
-|calendarIcon|Defines the content of the calendar button. Setting the value explicitly to `null` will hide the icon.|<ul><li>String: `"Calendar"`</li><li>React element: `<CalendarIcon />`</li></ul>|
-|className|Defines class name(s) that will be added along with "react-date-picker" to the main React-Date-Picker `<div>` element.|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
-|clearAriaLabel|Defines the `aria-label` for the clear button.|`"Clear value"`|
-|clearIcon|Defines the content of the clear button. Setting the value explicitly to `null` will hide the icon.|<ul><li>String: `"Clear"`</li><li>React element: `<ClearIcon />`</li></ul>|
-|dayAriaLabel|Defines the `aria-label` for the day input.|`"Year"`|
-|disabled|Defines whether the date picker should be disabled. Defaults to false.|`true`|
-|format|Defines input format based on [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table). Supported values are: `y`, `M`, `MM`, `MMM`, `MMMM`, `d`, `dd`.|`"y-MM-dd"`|
-|isOpen|Defines whether the calendar should be opened. Defaults to false.|`true`|
-|locale|Defines which locale should be used by the date picker and the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag). Defaults to user's browser settings.|`"hu-HU"`|
-|maxDate|Defines maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Date-Picker will ensure that no later date is selected.|Date: `new Date()`|
-|maxDetail|Defines the most detailed calendar view that the user shall see. View defined here also becomes the one on which clicking an item in the calendar will select a date and pass it to onChange. Can be "month", "year", "decade" or "century". Defaults to "month".|`"month"`|
-|minDate|Defines minimum date that the user can select. Periods partially overlapped by minDate will also be selectable, although React-Date-Picker will ensure that no earlier date is selected.|Date: `new Date()`|
-|minDetail|Defines the least detailed calendar view that the user shall see. Can be "month", "year", "decade" or "century". Defaults to "century".|`"century"`|
-|monthAriaLabel|Defines the `aria-label` for the month input.|`"Month"`|
-|name|Defines input name. Defaults to "date".|`"myCustomName"`|
-|nativeInputAriaLabel|Defines the `aria-label` for the native date input.|`"Date"`|
-|onCalendarClose|Function called when the calendar closes.|`() => alert('Calendar closed')`|
-|onCalendarOpen|Function called when the calendar opens.|`() => alert('Calendar opened')`|
-|onChange|Function called when the user clicks an item on the most detailed view available.|`(value) => alert('New date is: ', value)`|
-|required|Defines whether date input should be required. Defaults to false.|`true`|
-|returnValue|Defines which dates shall be passed by the calendar to the onChange function and onClick{Period} functions. Can be "start", "end" or "range". The latter will cause an array with start and end values to be passed. Defaults to "start".|`"range"`|
-|showLeadingZeros|Defines whether leading zeros should be rendered in date inputs. Defaults to false.|`true`|
-|value|Defines the value of the input.|<ul><li>Date: `new Date()`</li><li>An array of dates: `[new Date(2017, 0, 1), new Date(2017, 7, 1)]`</li></ul>|
-|yearAriaLabel|Defines the `aria-label` for the year input.|`"Year"`|
+|Prop name|Description|Default value|Example values|
+|----|----|----|----|
+|calendarAriaLabel|`aria-label` for the calendar button.|n/a|`"Toggle clock"`|
+|calendarClassName|Class name(s) that will be added along with "react-calendar" to the main React-Calendar `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
+|calendarIcon|Content of the calendar button. Setting the value explicitly to `null` will hide the icon.| (default icon)|<ul><li>String: `"Calendar"`</li><li>React element: `<CalendarIcon />`</li></ul>|
+|className|Class name(s) that will be added along with `"react-date-picker"` to the main React-Date-Picker `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
+|clearAriaLabel|`aria-label` for the clear button.|n/a|`"Clear value"`|
+|clearIcon|Content of the clear button. Setting the value explicitly to `null` will hide the icon.|(default icon)|<ul><li>String: `"Clear"`</li><li>React element: `<ClearIcon />`</li></ul>|
+|dayAriaLabel| `aria-label` for the day input.|n/a|`"Year"`|
+|disabled|Whether the date picker should be disabled.|`false`|`true`|
+|format|Input format based on [Unicode Technical Standard #35](https://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table). Supported values are: `y`, `M`, `MM`, `MMM`, `MMMM`, `d`, `dd`.|n/a|`"y-MM-dd"`|
+|isOpen|Whether the calendar should be opened.|`false`|`true`|
+|locale|Locale that should be used by the date picker and the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings.|`"hu-HU"`|
+|maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Date-Picker will ensure that no later date is selected.|n/a|Date: `new Date()`|
+|maxDetail|The most detailed calendar view that the user shall see. View defined here also becomes the one on which clicking an item in the calendar will select a date and pass it to onChange. Can be `"month"`, `"year"`, `"decade"` or `"century"`.|`"month"`|`"year"`|
+|minDate|Minimum date that the user can select. Periods partially overlapped by minDate will also be selectable, although React-Date-Picker will ensure that no earlier date is selected.|n/a|Date: `new Date()`|
+|minDetail|The least detailed calendar view that the user shall see. Can be `"month"`, `"year"`, `"decade"` or `"century"`|`"century"`|`"decade"`|
+|monthAriaLabel|`aria-label` for the month input.|n/a|`"Month"`|
+|name|Input name.|`"date"`|`"myCustomName"`|
+|nativeInputAriaLabel|`aria-label` for the native date input.|n/a|`"Date"`|
+|onCalendarClose|Function called when the calendar closes.|n/a|`() => alert('Calendar closed')`|
+|onCalendarOpen|Function called when the calendar opens.|n/a|`() => alert('Calendar opened')`|
+|onChange|Function called when the user clicks an item on the most detailed view available.|n/a|`(value) => alert('New date is: ', value)`|
+|required|Whether date input should be required.|`false`|`true`|
+|returnValue|Which dates shall be passed by the calendar to the onChange function and onClick{Period} functions. Can be "start", "end" or "range". The latter will cause an array with start and end values to be passed.|`"start"`|`"range"`|
+|showLeadingZeros|Whether leading zeros should be rendered in date inputs.|`false`|`true`|
+|value|Input value.|n/a|<ul><li>Date: `new Date()`</li><li>An array of dates: `[new Date(2017, 0, 1), new Date(2017, 7, 1)]`</li></ul>|
+|yearAriaLabel|`aria-label` for the year input.|n/a|`"Year"`|
 
 ### Calendar
 


### PR DESCRIPTION
Hi. I just thought it's easier to read if there will be a separate column for default values instead of having the values listed in the description. I also moved the list of "can be" values to the example values column.