### PR TITLE
Add missing "format" prop to typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare module "react-date-picker" {
     className?: string | string[];
     clearIcon?: JSX.Element | null;
     disabled?: boolean;
+    format?: string;
     isOpen?: boolean;
     name?: string;
     required?: boolean;


### PR DESCRIPTION
Update DatePickerProps TypeScript typings by adding the missing `format` prop