### PR TITLE
Use user-provided placeholder in MonthSelect

### DIFF
--- a/src/DateInput/MonthSelect.jsx
+++ b/src/DateInput/MonthSelect.jsx
@@ -17,6 +17,7 @@ export default function MonthSelect({
   short,
   year,
   value,
+  placeholder,
   ...otherProps
 }) {
   const maxMonth = min(12, maxDate && year === getYear(maxDate) && getMonth(maxDate));
@@ -43,7 +44,7 @@ export default function MonthSelect({
     >
       {!value && (
         <option value="">
-          --
+          {placeholder !== void 0 ? placeholder : '--'}
         </option>
       )}
       {dates.map((date) => {

--- a/src/DateInput/MonthSelect.jsx
+++ b/src/DateInput/MonthSelect.jsx
@@ -44,7 +44,7 @@ export default function MonthSelect({
     >
       {!value && (
         <option value="">
-          {placeholder !== undefined ? placeholder : '--'}
+          {placeholder}
         </option>
       )}
       {dates.map((date) => {
@@ -81,4 +81,8 @@ MonthSelect.propTypes = {
   short: PropTypes.bool,
   value: PropTypes.number,
   year: PropTypes.number,
+};
+
+MonthSelect.defaultProps = {
+  placeholder: '--',
 };

--- a/src/DateInput/MonthSelect.jsx
+++ b/src/DateInput/MonthSelect.jsx
@@ -44,7 +44,7 @@ export default function MonthSelect({
     >
       {!value && (
         <option value="">
-          {placeholder !== void 0 ? placeholder : '--'}
+          {placeholder !== undefined ? placeholder : '--'}
         </option>
       )}
       {dates.map((date) => {

--- a/src/DateInput/__tests__/MonthSelect.jsx
+++ b/src/DateInput/__tests__/MonthSelect.jsx
@@ -38,7 +38,7 @@ describe('MonthSelect', () => {
     expect(select.prop('aria-label')).toBe(monthAriaLabel);
   });
 
-  it('applies given placeholder properly', () => {
+  it('applies given placeholder properly when provided', () => {
     const monthPlaceholder = 'mm';
 
     const component = mount(
@@ -48,9 +48,19 @@ describe('MonthSelect', () => {
       />
     );
 
-    const select = component.find('select');
+    const options = component.find('select').find('option');
 
-    expect(select.prop('placeholder')).toBe(monthPlaceholder);
+    expect(options.get(0).props.children).toBe(monthPlaceholder);
+  });
+
+  it('applies given placeholder properly when not provided', () => {
+    const component = mount(
+      <MonthSelect {...defaultProps} />
+    );
+
+    const options = component.find('select').find('option');
+
+    expect(options.get(0).props.children).toBe('--');
   });
 
   it('has proper name defined', () => {


### PR DESCRIPTION
The placeholder in the `MonthSelect` component (implemented via a disabled `<option>`) was hard-coded to `"--"`. This PR updates the component to use the user-provided placeholder.

Also, the unit test checking the `MonthSelect` placeholder was failing. I updated it and added another test, so now we test for the case when the user provides a placeholder and when they do not.