### PR TITLE
Add support for allowInvalidValues flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Displays an input field complete with custom inputs, native input, and a calenda
 
 |Prop name|Description|Default value|Example values|
 |----|----|----|----|
+|allowInvalidValues|Whether entering an invalid value (eg. date outside of a given range) should trigger onChange function.|`false`|`true`|
 |autoFocus|Automatically focuses the input on mount.|n/a|`true`|
 |calendarAriaLabel|`aria-label` for the calendar button.|n/a|`"Toggle calendar"`|
 |calendarClassName|Class name(s) that will be added along with `"react-calendar"` to the main React-Calendar `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -412,7 +412,8 @@ export default class DateInput extends PureComponent {
 
     const values = {};
     formElements.forEach((formElement) => {
-      values[formElement.name] = formElement.value;
+      // eslint-disable-next-line react/destructuring-assignment
+      values[formElement.name] = this.state[formElement.name];
     });
 
     if (formElements.every(formElement => !formElement.value)) {

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -361,7 +361,7 @@ export default class DateInput extends PureComponent {
     const { name, value } = event.target;
 
     this.setState(
-      { [name]: value ? parseInt(value, 10) : null },
+      { [name]: value },
       this.onChangeExternal,
     );
   }

--- a/src/DateInput.jsx
+++ b/src/DateInput.jsx
@@ -383,7 +383,7 @@ export default class DateInput extends PureComponent {
       }
 
       const [yearString, monthString, dayString] = value.split('-');
-      const year = parseInt(yearString, 10);
+      const year = parseInt(yearString, 10) || 0;
       const monthIndex = parseInt(monthString, 10) - 1 || 0;
       const day = parseInt(dayString, 10) || 1;
 
@@ -402,7 +402,7 @@ export default class DateInput extends PureComponent {
    * calls props.onChange.
    */
   onChangeExternal = () => {
-    const { onChange } = this.props;
+    const { allowInvalidValues, onChange } = this.props;
 
     if (!onChange) {
       return;
@@ -418,9 +418,10 @@ export default class DateInput extends PureComponent {
     if (formElements.every(formElement => !formElement.value)) {
       onChange(null, false);
     } else if (
-      formElements.every(formElement => formElement.value && formElement.checkValidity())
+      allowInvalidValues
+      || formElements.every(formElement => formElement.value && formElement.checkValidity())
     ) {
-      const year = parseInt(values.year, 10);
+      const year = parseInt(values.year, 10) || 0;
       const monthIndex = parseInt(values.month, 10) - 1 || 0;
       const day = parseInt(values.day || 1, 10);
 
@@ -595,6 +596,7 @@ const isValue = PropTypes.oneOfType([
 ]);
 
 DateInput.propTypes = {
+  allowInvalidValues: PropTypes.bool,
   autoFocus: PropTypes.bool,
   className: PropTypes.string.isRequired,
   dayAriaLabel: PropTypes.string,

--- a/src/DateInput/DayInput.jsx
+++ b/src/DateInput/DayInput.jsx
@@ -44,6 +44,8 @@ export default function DayInput({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 DayInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -51,13 +53,13 @@ DayInput.propTypes = {
   itemRef: PropTypes.func,
   maxDate: isMaxDate,
   minDate: isMinDate,
-  month: PropTypes.number,
+  month: isNumberOrString,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onKeyUp: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
-  year: PropTypes.number,
+  value: isNumberOrString,
+  year: isNumberOrString,
 };

--- a/src/DateInput/Input.jsx
+++ b/src/DateInput/Input.jsx
@@ -124,6 +124,8 @@ export default function Input({
   ];
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 Input.propTypes = {
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
@@ -136,5 +138,5 @@ Input.propTypes = {
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
   step: PropTypes.number,
-  value: PropTypes.number,
+  value: isNumberOrString,
 };

--- a/src/DateInput/MonthInput.jsx
+++ b/src/DateInput/MonthInput.jsx
@@ -30,6 +30,8 @@ export default function MonthInput({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 MonthInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -43,6 +45,6 @@ MonthInput.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
-  value: PropTypes.number,
-  year: PropTypes.number,
+  value: isNumberOrString,
+  year: isNumberOrString,
 };

--- a/src/DateInput/MonthSelect.jsx
+++ b/src/DateInput/MonthSelect.jsx
@@ -69,6 +69,8 @@ export default function MonthSelect({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 MonthSelect.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -83,6 +85,6 @@ MonthSelect.propTypes = {
   placeholder: PropTypes.string,
   required: PropTypes.bool,
   short: PropTypes.bool,
-  value: PropTypes.number,
-  year: PropTypes.number,
+  value: isNumberOrString,
+  year: isNumberOrString,
 };

--- a/src/DateInput/YearInput.jsx
+++ b/src/DateInput/YearInput.jsx
@@ -37,6 +37,8 @@ export default function YearInput({
   );
 }
 
+const isNumberOrString = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
 YearInput.propTypes = {
   ariaLabel: PropTypes.string,
   className: PropTypes.string.isRequired,
@@ -49,6 +51,6 @@ YearInput.propTypes = {
   onKeyUp: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  value: PropTypes.number,
+  value: isNumberOrString,
   valueType: isValueType,
 };

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -114,6 +114,7 @@ export default class DatePicker extends PureComponent {
 
   renderInputs() {
     const {
+      allowInvalidValues,
       autoFocus,
       calendarAriaLabel,
       calendarIcon,
@@ -161,6 +162,7 @@ export default class DatePicker extends PureComponent {
         <DateInput
           {...ariaLabelProps}
           {...placeholderProps}
+          allowInvalidValues={allowInvalidValues}
           autoFocus={autoFocus}
           className={`${baseClassName}__inputGroup`}
           disabled={disabled}
@@ -310,6 +312,7 @@ const isValue = PropTypes.oneOfType([
 ]);
 
 DatePicker.propTypes = {
+  allowInvalidValues: PropTypes.bool,
   autoFocus: PropTypes.bool,
   calendarAriaLabel: PropTypes.string,
   calendarClassName: PropTypes.oneOfType([

--- a/src/shared/utils.js
+++ b/src/shared/utils.js
@@ -1,21 +1,4 @@
 /**
- * Returns a value no smaller than min and no larger than max.
- *
- * @param {*} value Value to return.
- * @param {*} min Minimum return value.
- * @param {*} max Maximum return value.
- */
-export function between(value, min, max) {
-  if (min && min > value) {
-    return min;
-  }
-  if (max && max < value) {
-    return max;
-  }
-  return value;
-}
-
-/**
  * Calls a function, if it's defined, with specified arguments
  * @param {Function} fn
  * @param {Object} args

--- a/src/shared/utils.spec.js
+++ b/src/shared/utils.spec.js
@@ -1,45 +1,8 @@
 import {
-  between,
   callIfDefined,
   safeMin,
   safeMax,
 } from './utils';
-
-describe('between', () => {
-  it('returns value when value is within set boundaries', () => {
-    const value = new Date(2017, 6, 1);
-    const min = new Date(2017, 0, 1);
-    const max = new Date(2017, 11, 1);
-    const result = between(value, min, max);
-
-    expect(result).toBe(value);
-  });
-
-  it('returns min when value is smaller than min', () => {
-    const value = new Date(2017, 0, 1);
-    const min = new Date(2017, 6, 1);
-    const max = new Date(2017, 11, 1);
-    const result = between(value, min, max);
-
-    expect(result).toBe(min);
-  });
-
-  it('returns max when value is larger than max', () => {
-    const value = new Date(2017, 11, 1);
-    const min = new Date(2017, 0, 1);
-    const max = new Date(2017, 6, 1);
-    const result = between(value, min, max);
-
-    expect(result).toBe(max);
-  });
-
-  it('returns value when min and max are not provided', () => {
-    const value = new Date(2017, 6, 1);
-    const result = between(value, null, undefined);
-
-    expect(result).toBe(value);
-  });
-});
 
 describe('callIfDefined', () => {
   it('calls given function if defined', () => {


### PR DESCRIPTION
Allows invalid (out of range) values to trigger onChange callback.

Side effect: Values are no longer enforced to be between minDate and maxDate. Still, if input validation was correct, these values shouldn't be invalid in the first place.