### PR TITLE
Add type definition for react-calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@types/react-calendar": "^3.0.0",
     "@wojtekmaj/date-utils": "^1.0.2",
     "get-user-locale": "^1.2.0",
     "make-event-props": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1083,6 +1083,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.9.1.tgz#96f606f8cd67fb018847d9b61e93997dabdefc72"
   integrity sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==
 
+"@types/react-calendar@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-calendar/-/react-calendar-3.0.0.tgz#3d707468db20f59bc51fc8e9a09ef493b872162e"
+  integrity sha512-h00bPn86LZIAbmedFDrp0lmv7g3KHTKY85er710UAlUMocVZZEPhKma9ZFuFHlH9S0KOlKfe3ZeM/WC4+JVYCw==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"


### PR DESCRIPTION
Added type definition package for react-calendar to dependencies so that it is included on published package.

This was causing errors in TS projects using types from react-calendar e.g. min/max detail, the workaround is people having to add the dependency to their own project, this resolves that requirement.