### PR TITLE
Add ability to place calendar button on the left side of input field

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Displays an input field complete with custom inputs, native input, and a calenda
 |----|----|----|----|
 |autoFocus|Automatically focuses the input on mount.|n/a|`true`|
 |calendarAriaLabel|`aria-label` for the calendar button.|n/a|`"Toggle calendar"`|
+|calendarButtonPosition|Position of the calendar button. Placed on the right side by default; setting value to `"left"` will move it to the left side (before the input)|`"right"`|`"left"`|
 |calendarClassName|Class name(s) that will be added along with `"react-calendar"` to the main React-Calendar `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|
 |calendarIcon|Content of the calendar button. Setting the value explicitly to `null` will hide the icon.|(default icon)|<ul><li>String: `"Calendar"`</li><li>React element: `<CalendarIcon />`</li></ul>|
 |className|Class name(s) that will be added along with `"react-date-picker"` to the main React-Date-Picker `<div>` element.|n/a|<ul><li>String: `"class1 class2"`</li><li>Array of strings: `["class1", "class2 class3"]`</li></ul>|

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare module "react-date-picker" {
   export default function DatePicker(props: DatePickerProps): JSX.Element;
 
   export interface DatePickerProps extends CalendarProps {
+    calendarButtonPosition?: 'left' | 'right';
     calendarClassName?: string | string[];
     calendarIcon?: JSX.Element | null;
     className?: string | string[];

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -118,6 +118,7 @@ export default class DatePicker extends PureComponent {
     const {
       autoFocus,
       calendarAriaLabel,
+      calendarButtonPosition,
       calendarIcon,
       clearAriaLabel,
       clearIcon,
@@ -158,8 +159,23 @@ export default class DatePicker extends PureComponent {
       yearPlaceholder,
     };
 
+    const renderCalendarButton = () => calendarIcon !== null && !disableCalendar && (
+      <button
+        aria-label={calendarAriaLabel}
+        className={`${baseClassName}__calendar-button ${baseClassName}__button`}
+        disabled={disabled}
+        onBlur={this.resetValue}
+        onClick={this.toggleCalendar}
+        onFocus={this.stopPropagation}
+        type="button"
+      >
+        {calendarIcon}
+      </button>
+    );
+
     return (
       <div className={`${baseClassName}__wrapper`}>
+        {calendarButtonPosition === 'left' && renderCalendarButton()}
         <DateInput
           {...ariaLabelProps}
           {...placeholderProps}
@@ -191,19 +207,7 @@ export default class DatePicker extends PureComponent {
             {clearIcon}
           </button>
         )}
-        {calendarIcon !== null && !disableCalendar && (
-          <button
-            aria-label={calendarAriaLabel}
-            className={`${baseClassName}__calendar-button ${baseClassName}__button`}
-            disabled={disabled}
-            onBlur={this.resetValue}
-            onClick={this.toggleCalendar}
-            onFocus={this.stopPropagation}
-            type="button"
-          >
-            {calendarIcon}
-          </button>
-        )}
+        {calendarButtonPosition === 'right' && renderCalendarButton()}
       </div>
     );
   }
@@ -305,6 +309,7 @@ DatePicker.defaultProps = {
   closeCalendar: true,
   isOpen: null,
   returnValue: 'start',
+  calendarButtonPosition: 'right',
 };
 
 const isValue = PropTypes.oneOfType([
@@ -315,6 +320,7 @@ const isValue = PropTypes.oneOfType([
 DatePicker.propTypes = {
   autoFocus: PropTypes.bool,
   calendarAriaLabel: PropTypes.string,
+  calendarButtonPosition: PropTypes.oneOf(['left', 'right']),
   calendarClassName: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.arrayOf(PropTypes.string),

--- a/src/DatePicker.spec.jsx
+++ b/src/DatePicker.spec.jsx
@@ -184,7 +184,31 @@ describe('DatePicker', () => {
       <DatePicker />
     );
 
-    const calendarButton = component.find('button.react-date-picker__calendar-button');
+    const calendarButton = component.find(
+      'button.react-date-picker__clear-button + button.react-date-picker__calendar-button'
+    );
+
+    expect(calendarButton).toHaveLength(1);
+  });
+
+  it('renders calendar button on the left side', () => {
+    const component = mount(
+      <DatePicker calendarButtonPosition="left" />
+    );
+
+    const calendarButton = component.find('button.react-date-picker__calendar-button + DateInput');
+
+    expect(calendarButton).toHaveLength(1);
+  });
+
+  it('renders calendar button on the right side', () => {
+    const component = mount(
+      <DatePicker calendarButtonPosition="right" />
+    );
+
+    const calendarButton = component.find(
+      'button.react-date-picker__clear-button + button.react-date-picker__calendar-button'
+    );
 
     expect(calendarButton).toHaveLength(1);
   });


### PR DESCRIPTION
Add a component property to display calendar button at the beginning of the input field. Without any style customization, this will produce the following output:
![изображение](https://user-images.githubusercontent.com/2121539/79953237-81834700-84b6-11ea-9f60-184141b2a3bc.png)
With the customization, it will become possible to show something as nice-looking as this:
![изображение](https://user-images.githubusercontent.com/2121539/79953025-3b2de800-84b6-11ea-8b80-f22bf41fac36.png)
