### PR TITLE
Implement prop for openCalendarOnFocus

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,8 @@
     }],
     "react/require-default-props": "off",
     "react/sort-prop-types": "error",
-    "react/state-in-constructor": ["error", "never"]
+    "react/state-in-constructor": ["error", "never"],
+    "linebreak-style": ["off"]
   },
   "overrides": [
     {

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Displays an input field complete with custom inputs, native input, and a calenda
 |onCalendarClose|Function called when the calendar closes.|n/a|`() => alert('Calendar closed')`|
 |onCalendarOpen|Function called when the calendar opens.|n/a|`() => alert('Calendar opened')`|
 |onChange|Function called when the user clicks an item on the most detailed view available.|n/a|`(value) => alert('New date is: ', value)`|
+|openCalendarOnFocus|Whether the calendar should open automatically on input focus.|`true`|`false`|
 |required|Whether date input should be required.|`false`|`true`|
 |returnValue|Which dates shall be passed by the calendar to the onChange function and onClick{Period} functions. Can be `"start"`, `"end"` or `"range"`. The latter will cause an array with start and end values to be passed.|`"start"`|`"range"`|
 |showLeadingZeros|Whether leading zeros should be rendered in date inputs.|`false`|`true`|

--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,7 @@ declare module "react-date-picker" {
     name?: string;
     onCalendarOpen?: () => void;
     onCalendarClose?: () => void;
+    openCalendarOnFocus?: boolean;
     required?: boolean;
     showLeadingZeros?: boolean;
     yearPlaceholder?: string;

--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     {
       "name": "Marco Fugaro",
       "email": "marco.fugaro@gmail.com"
+    },
+    {
+      "name": "Matt Gandley",
+      "email": "mgandley@gmail.com"
     }
   ],
   "license": "MIT",

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -70,7 +70,7 @@ export default class DatePicker extends PureComponent {
   }
 
   onFocus = (event) => {
-    const { disabled, onFocus } = this.props;
+    const { disabled, onFocus, openCalendarOnFocus } = this.props;
 
     if (onFocus) {
       onFocus(event);
@@ -81,7 +81,9 @@ export default class DatePicker extends PureComponent {
       return;
     }
 
-    this.openCalendar();
+    if (openCalendarOnFocus) {
+      this.openCalendar();
+    }
   }
 
   openCalendar = () => {
@@ -304,6 +306,7 @@ DatePicker.defaultProps = {
   clearIcon: ClearIcon,
   closeCalendar: true,
   isOpen: null,
+  openCalendarOnFocus: true,
   returnValue: 'start',
 };
 
@@ -345,6 +348,7 @@ DatePicker.propTypes = {
   onCalendarOpen: PropTypes.func,
   onChange: PropTypes.func,
   onFocus: PropTypes.func,
+  openCalendarOnFocus: PropTypes.bool,
   required: PropTypes.bool,
   returnValue: PropTypes.oneOf(['start', 'end', 'range']),
   showLeadingZeros: PropTypes.bool,

--- a/src/DatePicker.spec.jsx
+++ b/src/DatePicker.spec.jsx
@@ -266,6 +266,24 @@ describe('DatePicker', () => {
     expect(calendar2).toHaveLength(1);
   });
 
+  it('does not open Calendar component when focusing on an input inside, if openCalendarOnFocus is false', () => {
+    const component = mount(
+      <DatePicker openCalendarOnFocus={false} />
+    );
+
+    const calendar = component.find('Calendar');
+    const input = component.find('input[name="day"]');
+
+    expect(calendar).toHaveLength(0);
+
+    input.simulate('focus');
+    component.update();
+
+    const calendar2 = component.find('Calendar');
+
+    expect(calendar2).toHaveLength(0);
+  });
+
   it('closes Calendar component when clicked outside', () => {
     const root = document.createElement('div');
     document.body.appendChild(root);


### PR DESCRIPTION
Adds a boolean prop to DateInput, `openCalendarOnFocus` that defaults to true.  When this prop is set to false, the calendar will not open automatically on focus of the input fields - instead, the user needs to click or toggle the calendar icon button in order to expose the calendar dropdown.