### PR TITLE
Fix manual input on Firefox when maxRange is set (fixes #309)

### DIFF
--- a/src/DateInput/Input.jsx
+++ b/src/DateInput/Input.jsx
@@ -51,7 +51,7 @@ function makeOnKeyPress(maxLength) {
     const isNumberKey = !isNaN(parseInt(key, 10));
     const selection = getSelectionString();
 
-    if (isNumberKey && (selection || value.length < maxLength)) {
+    if (isNumberKey && (selection || value.length <= maxLength)) {
       return;
     }
 


### PR DESCRIPTION
This would not work in Firefox when the whole value was selected, since the code would incorrectly check the value-length on Firefox on keypresses. This did not cause problems in Chrome, since there the selection is available for number inputs and the value-length condition would not be checked at all.