### PR TITLE
Remove leading zero span

### DIFF
--- a/src/DateInput/DayInput.spec.jsx
+++ b/src/DateInput/DayInput.spec.jsx
@@ -21,50 +21,6 @@ describe('DayInput', () => {
     expect(input).toHaveLength(1);
   });
 
-  it('renders "0" given showLeadingZeros if day is <10', () => {
-    const component = mount(
-      <DayInput
-        {...defaultProps}
-        showLeadingZeros
-        value={9}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).toContain('0');
-    expect(input.prop('className')).toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
-  it('does not render "0" given showLeadingZeros if day is >=10', () => {
-    const component = mount(
-      <DayInput
-        {...defaultProps}
-        showLeadingZeros
-        value={10}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).not.toContain('0');
-    expect(input.prop('className')).not.toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
-  it('does not render "0" if not given showLeadingZeros', () => {
-    const component = mount(
-      <DayInput
-        {...defaultProps}
-        value={9}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).not.toContain('0');
-    expect(input.prop('className')).not.toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
   it('applies given aria-label properly', () => {
     const dayAriaLabel = 'Day';
 

--- a/src/DateInput/Input.jsx
+++ b/src/DateInput/Input.jsx
@@ -81,8 +81,7 @@ export default function Input({
   const hasLeadingZero = showLeadingZeros && value !== null && value < 10;
   const maxLength = max.toString().length;
 
-  return [
-    (hasLeadingZero && <span key="leadingZero" className={`${className}__leadingZero`}>0</span>),
+  return (
     <input
       key="input"
       aria-label={ariaLabel}
@@ -91,7 +90,6 @@ export default function Input({
       className={mergeClassNames(
         `${className}__input`,
         `${className}__${nameForClass || name}`,
-        hasLeadingZero && `${className}__input--hasLeadingZero`,
       )}
       data-input="true"
       disabled={disabled}
@@ -123,9 +121,9 @@ export default function Input({
       required={required}
       step={step}
       type="number"
-      value={value !== null ? value : ''}
-    />,
-  ];
+      value={value !== null ? (hasLeadingZero ? `0${value}` : value) : ''}
+    />
+  );
 }
 
 Input.propTypes = {

--- a/src/DateInput/Input.jsx
+++ b/src/DateInput/Input.jsx
@@ -80,6 +80,7 @@ export default function Input({
 }) {
   const hasLeadingZero = showLeadingZeros && value !== null && value < 10;
   const maxLength = max.toString().length;
+  const getValue = () => (hasLeadingZero ? `0${value}` : value);
 
   return (
     <input
@@ -121,21 +122,25 @@ export default function Input({
       required={required}
       step={step}
       type="number"
-      value={value !== null ? (hasLeadingZero ? `0${value}` : value) : ''}
+      value={value !== null ? getValue() : ''}
     />
   );
 }
 
 Input.propTypes = {
   ariaLabel: PropTypes.string,
+  autoFocus: PropTypes.bool,
   className: PropTypes.string.isRequired,
   disabled: PropTypes.bool,
   itemRef: PropTypes.func,
   max: PropTypes.number,
   min: PropTypes.number,
+  name: PropTypes.string,
+  nameForClass: PropTypes.string,
   onChange: PropTypes.func,
   onKeyDown: PropTypes.func,
   onKeyUp: PropTypes.func,
+  placeholder: PropTypes.string,
   required: PropTypes.bool,
   showLeadingZeros: PropTypes.bool,
   step: PropTypes.number,

--- a/src/DateInput/MonthInput.spec.jsx
+++ b/src/DateInput/MonthInput.spec.jsx
@@ -21,50 +21,6 @@ describe('MonthInput', () => {
     expect(input).toHaveLength(1);
   });
 
-  it('renders "0" given showLeadingZeros if day is <10', () => {
-    const component = mount(
-      <MonthInput
-        {...defaultProps}
-        showLeadingZeros
-        value={9}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).toContain('0');
-    expect(input.prop('className')).toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
-  it('does not render "0" given showLeadingZeros if day is >=10', () => {
-    const component = mount(
-      <MonthInput
-        {...defaultProps}
-        showLeadingZeros
-        value={10}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).not.toContain('0');
-    expect(input.prop('className')).not.toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
-  it('does not render "0" if not given showLeadingZeros', () => {
-    const component = mount(
-      <MonthInput
-        {...defaultProps}
-        value={9}
-      />
-    );
-
-    const input = component.find('input');
-
-    expect(component.text()).not.toContain('0');
-    expect(input.prop('className')).not.toContain(`${defaultProps.className}__input--hasLeadingZero`);
-  });
-
   it('applies given aria-label properly', () => {
     const monthAriaLabel = 'Month';
 

--- a/src/DatePicker.less
+++ b/src/DatePicker.less
@@ -54,11 +54,6 @@
       &:invalid {
         background: fade(red, 10%);
       }
-
-      &--hasLeadingZero {
-        margin-left: -@digit-width;
-        padding-left: calc(~"1px + " @digit-width);
-      }
     }
   }
 


### PR DESCRIPTION
Hi @wojtekmaj,

First of all thanks for all the wonderful libraries you have built. This PR solves a problem I came across when I was working with [react-daterange-picker](https://github.com/wojtekmaj/react-daterange-picker). 

I had to customize the style of the calendar for my needs. So, I added some custom styles for the `inputGroup`. That clashed with the [style you have to manage the leading zeros](https://github.com/wojtekmaj/react-date-picker/blob/v8.0.3/src/DateInput/Input.jsx#L94) (For your reference I've attached a GIF below).

This PR eliminates the issue. Let me know if I'm wrong somewhere or I have to change something in the PR.

![react date picker leading zero span element problem](https://i.imgur.com/O74l6IY.gif)