### PR TITLE
add seperate min/max for calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,10 @@ Displays an input field complete with custom inputs, native input, and a calenda
 |isOpen|Whether the calendar should be opened.|`false`|`true`|
 |locale|Locale that should be used by the date picker and the calendar. Can be any [IETF language tag](https://en.wikipedia.org/wiki/IETF_language_tag).|User's browser settings|`"hu-HU"`|
 |maxDate|Maximum date that the user can select. Periods partially overlapped by maxDate will also be selectable, although React-Date-Picker will ensure that no later date is selected.|n/a|Date: `new Date()`|
+|maxDateCalendar|Maximum date that the calendar can select. Periods partially overlapped by maxDate will also be selectable, although React-Date-Picker will ensure that no later date is selected.|n/a|Date: `new Date()`|
 |maxDetail|The most detailed calendar view that the user shall see. View defined here also becomes the one on which clicking an item in the calendar will select a date and pass it to onChange. Can be `"month"`, `"year"`, `"decade"` or `"century"`.|`"month"`|`"year"`|
 |minDate|Minimum date that the user can select. Periods partially overlapped by minDate will also be selectable, although React-Date-Picker will ensure that no earlier date is selected.|n/a|Date: `new Date()`|
+|minDateCalendar|Minimum date that the calendar can select. Periods partially overlapped by minDate will also be selectable, although React-Date-Picker will ensure that no earlier date is selected.|n/a|Date: `new Date()`|
 |minDetail|The least detailed calendar view that the user shall see. Can be `"month"`, `"year"`, `"decade"` or `"century"`.|`"century"`|`"decade"`|
 |monthAriaLabel|`aria-label` for the month input.|n/a|`"Month"`|
 |monthPlaceholder|`placeholder` for the month input.|`"--"`|`"mm"`|

--- a/src/DatePicker.jsx
+++ b/src/DatePicker.jsx
@@ -236,6 +236,10 @@ export default class DatePicker extends PureComponent {
       className: datePickerClassName, // Unused, here to exclude it from calendarProps
       onChange,
       value,
+      minDate,
+      maxDate,
+      minDateCalendar,
+      maxDateCalendar,
       ...calendarProps
     } = this.props;
 
@@ -249,6 +253,8 @@ export default class DatePicker extends PureComponent {
             onChange={this.onChange}
             value={value || null}
             {...calendarProps}
+            minDate={minDateCalendar || maxDate}
+            maxDate={maxDateCalendar || minDate}
           />
         </div>
       </Fit>
@@ -354,8 +360,10 @@ DatePicker.propTypes = {
   isOpen: PropTypes.bool,
   locale: PropTypes.string,
   maxDate: isMaxDate,
+  maxDateCalendar: isMaxDate,
   maxDetail: PropTypes.oneOf(allViews),
   minDate: isMinDate,
+  minDateCalendar: isMinDate,
   monthAriaLabel: PropTypes.string,
   monthPlaceholder: PropTypes.string,
   name: PropTypes.string,


### PR DESCRIPTION
So, I noticed chrome `html5` input will call onChange for an invalid date typed in, but the calendar will show correct dates.

This PR is to basically get `react-date-picker` to meet half way; basically someone can set min/max for the calendar and then self validate the actual onChange ~ 