### PR TITLE
Fix husky

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-date-picker",
-  "version": "9.2.0",
+  "name": "@ideriabin/react-date-picker",
+  "version": "9.2.2",
   "description": "A date picker for your React app.",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean": "rimraf dist",
     "copy-styles": "node ./copy-styles.mjs",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "postinstall": "husky install",
+    "prepare": "husky install",
     "prepack": "yarn clean && yarn build",
     "prettier": "prettier --check . --cache",
     "test": "yarn lint && yarn tsc && yarn prettier && yarn unit",


### PR DESCRIPTION
Husky docs recommend using `prepare` instead of `postinstall`:

https://typicode.github.io/husky/#/?id=install
typicode/husky#884

I ran into this problem while trying to install the fork of a package from Github.