### PR TITLE
Fixes out of sync calendar and input field

### DIFF
--- a/packages/react-date-picker/src/DatePicker.tsx
+++ b/packages/react-date-picker/src/DatePicker.tsx
@@ -637,7 +637,7 @@ export default function DatePicker(props: DatePickerProps) {
       ref={wrapper}
     >
       {renderInputs()}
-      {renderCalendar()}
+      {isOpen ? renderCalendar() : null}
     </div>
   );
 }

--- a/packages/react-date-picker/src/DatePicker.tsx
+++ b/packages/react-date-picker/src/DatePicker.tsx
@@ -470,6 +470,7 @@ export default function DatePicker(props: DatePickerProps) {
 
       if (
         target &&
+        (!target.id || !target.id.startsWith('radix-')) &&
         wrapperEl &&
         !wrapperEl.contains(target) &&
         (!calendarWrapperEl || !calendarWrapperEl.contains(target))


### PR DESCRIPTION
Enhance calendar visibility conditional rendering

This commit introduces an improvement where the calendar is now displayed only when the `isOpen` variable is set to `true`. This change addresses the bug where inconsistencies occurred if a user attempted to alter the date directly via the calendar widget and subsequently tried to modify the date through the corresponding input field. The fix ensures a smoother user experience by maintaining the expected behavior of the calendar's visibility and interaction.