### PR TITLE
Add improved day validation workaround for leap year date input bug

### DIFF
--- a/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { createRef } from 'react';
 import { render } from '@testing-library/react';
 
-import DayInput from './DayInput.js';
+import DayInput, { checkDayInputValidity, getMinMaxDays } from './DayInput.js';
 
 describe('DayInput', () => {
   const defaultProps = {
@@ -203,5 +203,93 @@ describe('DayInput', () => {
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('max', '15');
+  });
+});
+
+describe('getMinMaxDays', () => {
+  it('returns 1-31 by default', () => {
+    const result = getMinMaxDays({});
+    expect(result).toEqual({ minDay: 1, maxDay: 31 });
+  });
+
+  it('returns 1-29 given month is 2 and year is a leap year', () => {
+    const result = getMinMaxDays({ month: '2', year: '2020' });
+    expect(result).toEqual({ minDay: 1, maxDay: 29 });
+  });
+
+  it('returns 1-28 given month is 2 and year is not a leap year', () => {
+    const result = getMinMaxDays({ month: '2', year: '2021' });
+    expect(result).toEqual({ minDay: 1, maxDay: 28 });
+  });
+
+  it('returns 1-31 for january', () => {
+    const result = getMinMaxDays({ month: '1', year: '2021' });
+    expect(result).toEqual({ minDay: 1, maxDay: 31 });
+  });
+
+  it('returns 1-30 for november', () => {
+    const result = getMinMaxDays({ month: '11', year: '2021' });
+    expect(result).toEqual({ minDay: 1, maxDay: 30 });
+  });
+
+  it('returns minDay 15 if the given minDate fall on the same month and has a day value of 15', () => {
+    const result = getMinMaxDays({ minDate: new Date(2021, 10, 15), month: '11', year: '2021' });
+    expect(result).toEqual({ minDay: 15, maxDay: 30 });
+  });
+
+  it('returns maxDay 15 if the given maxDate fall on the same month and has a day value of 15', () => {
+    const result = getMinMaxDays({ maxDate: new Date(2021, 10, 15), month: '11', year: '2021' });
+    expect(result).toEqual({ minDay: 1, maxDay: 15 });
+  });
+});
+
+describe('checkDayInputValidity', () => {
+  const testCases = [
+    {
+      month: '1',
+      year: '2024',
+      dayValue: '1',
+      expectedValidity: true,
+    },
+
+    {
+      month: '2',
+      year: '2023',
+      dayValue: '29',
+      expectedValidity: false,
+    },
+    {
+      month: '2',
+      year: '2024',
+      dayValue: '29',
+      expectedValidity: true,
+    },
+    {
+      month: '2',
+      year: '2024',
+      dayValue: '30',
+      expectedValidity: false,
+    },
+    {
+      dayValue: '32',
+      expectedValidity: false,
+    },
+    {
+      dayValue: '31',
+      expectedValidity: true,
+    },
+  ];
+
+  testCases.forEach((testCase) => {
+    it(`returns ${testCase.expectedValidity} for day ${testCase.dayValue} in month ${testCase.month} and year ${testCase.year}`, () => {
+      const result = checkDayInputValidity(
+        {
+          month: testCase.month,
+          year: testCase.year,
+        },
+        testCase.dayValue,
+      );
+      expect(result).toBe(testCase.expectedValidity);
+    });
   });
 });

--- a/packages/react-date-picker/src/DateInput/DayInput.tsx
+++ b/packages/react-date-picker/src/DateInput/DayInput.tsx
@@ -18,6 +18,17 @@ export default function DayInput({
   year,
   ...otherProps
 }: DayInputProps): React.ReactElement {
+  const { maxDay, minDay } = getMinMaxDays({ minDate, maxDate, month, year });
+
+  return <Input max={maxDay} min={minDay} name="day" {...otherProps} />;
+}
+
+export function getMinMaxDays(args: DayInputProps): {
+  maxDay: number;
+  minDay: number;
+} {
+  const { minDate, maxDate, month, year } = args;
+
   const currentMonthMaxDays = (() => {
     if (!month) {
       return 31;
@@ -33,5 +44,19 @@ export default function DayInput({
   const maxDay = safeMin(currentMonthMaxDays, maxDate && isSameMonth(maxDate) && getDate(maxDate));
   const minDay = safeMax(1, minDate && isSameMonth(minDate) && getDate(minDate));
 
-  return <Input max={maxDay} min={minDay} name="day" {...otherProps} />;
+  return { maxDay, minDay };
+}
+
+export function checkDayInputValidity(inputProps: DayInputProps, dayValue?: string): boolean {
+  const { minDay, maxDay } = getMinMaxDays(inputProps);
+  // Create an in-memory input element
+  const input = document.createElement('input');
+  input.type = 'number';
+  input.name = 'day';
+  input.min = minDay.toString();
+  input.max = maxDay.toString();
+  input.required = true;
+  input.value = dayValue || '';
+  // The browser will now validate the value based on min/max/required
+  return input.checkValidity();
 }


### PR DESCRIPTION
Fixes: https://github.com/wojtekmaj/react-date-picker/issues/659

There is an issue when trying to input a date such as "29 / 02 / 2024" (February 29th 2024) which is a leap year and should be valid.

The validation runs into a state where the input fields are first rendered with the inputs
day: 29
month: 2
year: 202

which is not a leap year, and thus the day 29 is not valid for this state.

The problem occurs when running the onChangeExternal, which tries to read the validity state of the dayInput react Ref. However, that ref has last been rendered with a min/max number value calculated from the previous month and year (month 2 and year 202). Therefore the day input field still believes that the day 29 is not valid, even though we have just entered 2024 into the year field.

This workaround is to just use a new instance of a DOM input field that emulates what the real input field should do,
and check this validity value instead, which will be correct using the current updated values. The real input field values will become valid next render cycle. Ironic to make another "shadow DOM" inside react, but at least it works.

Added a bunch of unit tests for this case, and improved the test coverage of utility methods as well