### PR TITLE
Migrate from RTL to vitest-browser-react

### DIFF
--- a/packages/react-date-picker/package.json
+++ b/packages/react-date-picker/package.json
@@ -59,9 +59,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.2.2",
-    "@testing-library/dom": "^10.0.0",
-    "@testing-library/jest-dom": "^6.0.0",
-    "@testing-library/react": "^16.0.0",
     "@types/node": "*",
     "@types/react": "*",
     "@types/react-dom": "*",

--- a/packages/react-date-picker/src/DateInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput.spec.tsx
@@ -509,7 +509,7 @@ describe('DateInput', () => {
     const customInputs = Array.from(container.querySelectorAll('input[data-input]'));
 
     for (const customInput of customInputs) {
-      await userEvent.fill(customInput, '');
+      await userEvent.clear(customInput);
     }
 
     expect(onChange).toHaveBeenCalledTimes(1);

--- a/packages/react-date-picker/src/DateInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput.spec.tsx
@@ -25,8 +25,8 @@ describe('DateInput', () => {
     className: 'react-date-picker__inputGroup',
   };
 
-  it('renders a native input and custom inputs', () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+  it('renders a native input and custom inputs', async () => {
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const nativeInput = container.querySelector('input[type="date"]');
     const customInputs = container.querySelectorAll('input[data-input]');
@@ -35,8 +35,8 @@ describe('DateInput', () => {
     expect(customInputs).toHaveLength(3);
   });
 
-  it('does not render day input when maxDetail is "year" or less', () => {
-    const { container } = render(<DateInput {...defaultProps} maxDetail="year" />);
+  it('does not render day input when maxDetail is "year" or less', async () => {
+    const { container } = await render(<DateInput {...defaultProps} maxDetail="year" />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = container.querySelector('input[name="day"]');
@@ -49,8 +49,8 @@ describe('DateInput', () => {
     expect(yearInput).toBeInTheDocument();
   });
 
-  it('does not render day and month inputs when maxDetail is "decade" or less', () => {
-    const { container } = render(<DateInput {...defaultProps} maxDetail="decade" />);
+  it('does not render day and month inputs when maxDetail is "decade" or less', async () => {
+    const { container } = await render(<DateInput {...defaultProps} maxDetail="decade" />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = container.querySelector('input[name="day"]');
@@ -63,10 +63,10 @@ describe('DateInput', () => {
     expect(yearInput).toBeInTheDocument();
   });
 
-  it('shows a given date in all inputs correctly given Date (12-hour format)', () => {
+  it('shows a given date in all inputs correctly given Date (12-hour format)', async () => {
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} value={date} />);
+    const { container } = await render(<DateInput {...defaultProps} value={date} />);
 
     const nativeInput = container.querySelector('input[type="date"]');
     const customInputs = container.querySelectorAll('input[data-input]');
@@ -77,10 +77,10 @@ describe('DateInput', () => {
     expect(customInputs[2]).toHaveValue(2017);
   });
 
-  it('shows a given date in all inputs correctly given ISO string (12-hour format)', () => {
+  it('shows a given date in all inputs correctly given ISO string (12-hour format)', async () => {
     const date = '2017-09-30T00:00:00.000';
 
-    const { container } = render(<DateInput {...defaultProps} value={date} />);
+    const { container } = await render(<DateInput {...defaultProps} value={date} />);
 
     const nativeInput = container.querySelector('input[type="date"]');
     const customInputs = container.querySelectorAll('input[data-input]');
@@ -88,29 +88,17 @@ describe('DateInput', () => {
     expect(nativeInput).toHaveValue('2017-09-30');
     expect(customInputs[0]).toHaveValue(9);
     expect(customInputs[1]).toHaveValue(30);
-    expect(customInputs[2]).toHaveValue(2017);
-  });
-
-  itIfFullICU('shows a given date in all inputs correctly given Date (24-hour format)', () => {
-    const date = new Date(2017, 8, 30);
-
-    const { container } = render(<DateInput {...defaultProps} locale="de-DE" value={date} />);
-
-    const nativeInput = container.querySelector('input[type="date"]');
-    const customInputs = container.querySelectorAll('input[data-input]');
-
-    expect(nativeInput).toHaveValue('2017-09-30');
-    expect(customInputs[0]).toHaveValue(30);
-    expect(customInputs[1]).toHaveValue(9);
     expect(customInputs[2]).toHaveValue(2017);
   });
 
   itIfFullICU(
-    'shows a given date in all inputs correctly given ISO string (24-hour format)',
-    () => {
-      const date = '2017-09-30T00:00:00.000';
+    'shows a given date in all inputs correctly given Date (24-hour format)',
+    async () => {
+      const date = new Date(2017, 8, 30);
 
-      const { container } = render(<DateInput {...defaultProps} locale="de-DE" value={date} />);
+      const { container } = await render(
+        <DateInput {...defaultProps} locale="de-DE" value={date} />,
+      );
 
       const nativeInput = container.querySelector('input[type="date"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -122,8 +110,27 @@ describe('DateInput', () => {
     },
   );
 
-  it('shows empty value in all inputs correctly given null', () => {
-    const { container } = render(<DateInput {...defaultProps} value={null} />);
+  itIfFullICU(
+    'shows a given date in all inputs correctly given ISO string (24-hour format)',
+    async () => {
+      const date = '2017-09-30T00:00:00.000';
+
+      const { container } = await render(
+        <DateInput {...defaultProps} locale="de-DE" value={date} />,
+      );
+
+      const nativeInput = container.querySelector('input[type="date"]');
+      const customInputs = container.querySelectorAll('input[data-input]');
+
+      expect(nativeInput).toHaveValue('2017-09-30');
+      expect(customInputs[0]).toHaveValue(30);
+      expect(customInputs[1]).toHaveValue(9);
+      expect(customInputs[2]).toHaveValue(2017);
+    },
+  );
+
+  it('shows empty value in all inputs correctly given null', async () => {
+    const { container } = await render(<DateInput {...defaultProps} value={null} />);
 
     const nativeInput = container.querySelector('input[type="date"]');
     const customInputs = container.querySelectorAll('input[data-input]');
@@ -134,10 +141,10 @@ describe('DateInput', () => {
     expect(customInputs[2]).toHaveAttribute('value', '');
   });
 
-  it('clears the value correctly', () => {
+  it('clears the value correctly', async () => {
     const date = new Date(2017, 8, 30);
 
-    const { container, rerender } = render(<DateInput {...defaultProps} value={date} />);
+    const { container, rerender } = await render(<DateInput {...defaultProps} value={date} />);
 
     rerender(<DateInput {...defaultProps} value={null} />);
 
@@ -150,8 +157,8 @@ describe('DateInput', () => {
     expect(customInputs[2]).toHaveAttribute('value', '');
   });
 
-  it('renders custom inputs in a proper order (12-hour format)', () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+  it('renders custom inputs in a proper order (12-hour format)', async () => {
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
 
@@ -160,8 +167,8 @@ describe('DateInput', () => {
     expect(customInputs[2]).toHaveAttribute('name', 'year');
   });
 
-  itIfFullICU('renders custom inputs in a proper order (24-hour format)', () => {
-    const { container } = render(<DateInput {...defaultProps} locale="de-DE" />);
+  itIfFullICU('renders custom inputs in a proper order (24-hour format)', async () => {
+    const { container } = await render(<DateInput {...defaultProps} locale="de-DE" />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
 
@@ -171,8 +178,8 @@ describe('DateInput', () => {
   });
 
   describe('renders custom inputs in a proper order given format', () => {
-    it('renders "y" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="y" />);
+    it('renders "y" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="y" />);
 
       const componentInput = container.querySelector('input[name="year"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -181,8 +188,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "yyyy" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="yyyy" />);
+    it('renders "yyyy" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="yyyy" />);
 
       const componentInput = container.querySelector('input[name="year"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -191,8 +198,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "M" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="M" />);
+    it('renders "M" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="M" />);
 
       const componentInput = container.querySelector('input[name="month"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -201,8 +208,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "MM" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="MM" />);
+    it('renders "MM" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="MM" />);
 
       const componentInput = container.querySelector('input[name="month"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -211,8 +218,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "MMM" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="MMM" />);
+    it('renders "MMM" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="MMM" />);
 
       const componentSelect = container.querySelector('select[name="month"]');
       const customInputs = container.querySelectorAll('select');
@@ -221,8 +228,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "MMMM" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="MMMM" />);
+    it('renders "MMMM" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="MMMM" />);
 
       const componentSelect = container.querySelector('select[name="month"]');
       const customInputs = container.querySelectorAll('select');
@@ -231,8 +238,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "d" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="d" />);
+    it('renders "d" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="d" />);
 
       const componentInput = container.querySelector('input[name="day"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -241,8 +248,8 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('renders "dd" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="dd" />);
+    it('renders "dd" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="dd" />);
 
       const componentInput = container.querySelector('input[name="day"]');
       const customInputs = container.querySelectorAll('input[data-input]');
@@ -251,7 +258,7 @@ describe('DateInput', () => {
       expect(customInputs).toHaveLength(1);
     });
 
-    it('throws error for "ddd"', () => {
+    it('throws error for "ddd"', async () => {
       muteConsole();
 
       const renderComponent = () => render(<DateInput {...defaultProps} format="ddd" />);
@@ -261,8 +268,8 @@ describe('DateInput', () => {
       restoreConsole();
     });
 
-    it('renders "yyyy-MM-dd" properly', () => {
-      const { container } = render(<DateInput {...defaultProps} format="yyyy-MM-d" />);
+    it('renders "yyyy-MM-dd" properly', async () => {
+      const { container } = await render(<DateInput {...defaultProps} format="yyyy-MM-d" />);
 
       const monthInput = container.querySelector('input[name="month"]');
       const dayInput = container.querySelector('input[name="day"]');
@@ -277,8 +284,8 @@ describe('DateInput', () => {
     });
   });
 
-  it('renders proper input separators', () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+  it('renders proper input separators', async () => {
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const separators = container.querySelectorAll('.react-date-picker__inputGroup__divider');
 
@@ -287,8 +294,8 @@ describe('DateInput', () => {
     expect(separators[1]).toHaveTextContent('/');
   });
 
-  it('renders proper amount of separators', () => {
-    const { container } = render(<DateInput {...defaultProps} maxDetail="year" />);
+  it('renders proper amount of separators', async () => {
+    const { container } = await render(<DateInput {...defaultProps} maxDetail="year" />);
 
     const separators = container.querySelectorAll('.react-date-picker__inputGroup__divider');
     const customInputs = container.querySelectorAll('input[data-input]');
@@ -297,7 +304,7 @@ describe('DateInput', () => {
   });
 
   it('jumps to the next field when right arrow is pressed', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -309,7 +316,7 @@ describe('DateInput', () => {
   });
 
   it('jumps to the next field when separator key is pressed', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -326,7 +333,7 @@ describe('DateInput', () => {
   });
 
   it('does not jump to the next field when right arrow is pressed when the last input is focused', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const yearInput = customInputs[2] as HTMLInputElement;
@@ -337,7 +344,7 @@ describe('DateInput', () => {
   });
 
   it('jumps to the previous field when left arrow is pressed', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0];
@@ -349,7 +356,7 @@ describe('DateInput', () => {
   });
 
   it('does not jump to the previous field when left arrow is pressed when the first input is focused', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -360,7 +367,7 @@ describe('DateInput', () => {
   });
 
   it("jumps to the next field when a value which can't be extended to another valid value is entered", async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -372,7 +379,7 @@ describe('DateInput', () => {
   });
 
   it('jumps to the next field when a value as long as the length of maximum value is entered', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -401,7 +408,7 @@ describe('DateInput', () => {
 
     const date = new Date(2023, 3, 1);
 
-    const { container } = render(<DateInput {...defaultProps} locale="de-DE" value={date} />);
+    const { container } = await render(<DateInput {...defaultProps} locale="de-DE" value={date} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[0] as HTMLInputElement;
@@ -421,7 +428,7 @@ describe('DateInput', () => {
   });
 
   it('does not jump the next field when a value which can be extended to another valid value is entered', async () => {
-    const { container } = render(<DateInput {...defaultProps} />);
+    const { container } = await render(<DateInput {...defaultProps} />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -431,11 +438,13 @@ describe('DateInput', () => {
     expect(monthInput).toHaveFocus();
   });
 
-  it('triggers onChange correctly when changed custom input', () => {
+  it('triggers onChange correctly when changed custom input', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[1] as HTMLInputElement;
@@ -446,13 +455,15 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(new Date(2017, 8, 20), false);
   });
 
-  it('triggers onChange correctly when changed custom input with year < 100', () => {
+  it('triggers onChange correctly when changed custom input with year < 100', async () => {
     const onChange = vi.fn();
     const date = new Date();
     date.setFullYear(19, 8, 30);
     date.setHours(0, 0, 0, 0);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[1] as HTMLInputElement;
@@ -467,11 +478,11 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(nextDate, false);
   });
 
-  it('triggers onChange correctly when changed custom input with no year', () => {
+  it('triggers onChange correctly when changed custom input with no year', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(
+    const { container } = await render(
       <DateInput {...defaultProps} format="dd.MM" onChange={onChange} value={date} />,
     );
 
@@ -486,11 +497,13 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(new Date(currentYear, 8, 20), false);
   });
 
-  it('triggers onChange correctly when cleared custom inputs', () => {
+  it('triggers onChange correctly when cleared custom inputs', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const customInputs = Array.from(container.querySelectorAll('input[data-input]'));
 
@@ -502,11 +515,13 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(null, false);
   });
 
-  it('triggers onChange correctly when changed native input', () => {
+  it('triggers onChange correctly when changed native input', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 
@@ -516,11 +531,13 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(new Date(2017, 8, 20), false);
   });
 
-  it('triggers onChange correctly when changed native input with year < 100', () => {
+  it('triggers onChange correctly when changed native input with year < 100', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 
@@ -534,11 +551,13 @@ describe('DateInput', () => {
     expect(onChange).toHaveBeenCalledWith(nextDate, false);
   });
 
-  it('triggers onChange correctly when cleared native input', () => {
+  it('triggers onChange correctly when cleared native input', async () => {
     const onChange = vi.fn();
     const date = new Date(2017, 8, 30);
 
-    const { container } = render(<DateInput {...defaultProps} onChange={onChange} value={date} />);
+    const { container } = await render(
+      <DateInput {...defaultProps} onChange={onChange} value={date} />,
+    );
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 

--- a/packages/react-date-picker/src/DateInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { fireEvent, render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
+import { fireEvent } from '@testing-library/react';
 
 import DateInput from './DateInput.js';
 
@@ -263,7 +264,7 @@ describe('DateInput', () => {
 
       const renderComponent = () => render(<DateInput {...defaultProps} format="ddd" />);
 
-      expect(renderComponent).toThrow('Unsupported token: ddd');
+      await expect(renderComponent).rejects.toThrowError('Unsupported token: ddd');
 
       restoreConsole();
     });

--- a/packages/react-date-picker/src/DateInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput.spec.tsx
@@ -450,7 +450,7 @@ describe('DateInput', () => {
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[1] as HTMLInputElement;
 
-    fireEvent.change(dayInput, { target: { value: '20' } });
+    await userEvent.fill(dayInput, '20');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith(new Date(2017, 8, 20), false);
@@ -469,7 +469,7 @@ describe('DateInput', () => {
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[1] as HTMLInputElement;
 
-    fireEvent.change(dayInput, { target: { value: '20' } });
+    await userEvent.fill(dayInput, '20');
 
     const nextDate = new Date();
     nextDate.setFullYear(19, 8, 20);
@@ -490,7 +490,7 @@ describe('DateInput', () => {
     const customInputs = container.querySelectorAll('input[data-input]');
     const dayInput = customInputs[0] as HTMLInputElement;
 
-    fireEvent.change(dayInput, { target: { value: '20' } });
+    await userEvent.fill(dayInput, '20');
 
     const currentYear = new Date().getFullYear();
 
@@ -509,12 +509,27 @@ describe('DateInput', () => {
     const customInputs = Array.from(container.querySelectorAll('input[data-input]'));
 
     for (const customInput of customInputs) {
-      fireEvent.change(customInput, { target: { value: '' } });
+      await userEvent.fill(customInput, '');
     }
 
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onChange).toHaveBeenCalledWith(null, false);
   });
+
+  function setNativeValue(element: HTMLInputElement, value: string) {
+    const prototype = Object.getPrototypeOf(element);
+    const propertyDescriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+    const prototypeValueSetter = propertyDescriptor?.set;
+
+    if (prototypeValueSetter) {
+      prototypeValueSetter.call(element, value);
+    }
+  }
+
+  function triggerChange(element: HTMLInputElement, value: string) {
+    setNativeValue(element, value);
+    element.dispatchEvent(new Event('change', { bubbles: true, cancelable: true }));
+  }
 
   it('triggers onChange correctly when changed native input', async () => {
     const onChange = vi.fn();
@@ -526,7 +541,7 @@ describe('DateInput', () => {
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 
-    fireEvent.change(nativeInput, { target: { value: '2017-09-20' } });
+    triggerChange(nativeInput, '2017-09-20');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith(new Date(2017, 8, 20), false);
@@ -542,7 +557,7 @@ describe('DateInput', () => {
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 
-    fireEvent.change(nativeInput, { target: { value: '0019-09-20' } });
+    triggerChange(nativeInput, '0019-09-20');
 
     const nextDate = new Date();
     nextDate.setFullYear(19, 8, 20);
@@ -562,7 +577,7 @@ describe('DateInput', () => {
 
     const nativeInput = container.querySelector('input[type="date"]') as HTMLInputElement;
 
-    fireEvent.change(nativeInput, { target: { value: '' } });
+    triggerChange(nativeInput, '');
 
     expect(onChange).toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledWith(null, false);

--- a/packages/react-date-picker/src/DateInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput.spec.tsx
@@ -1,7 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
-import { fireEvent } from '@testing-library/react';
 
 import DateInput from './DateInput.js';
 
@@ -391,6 +390,18 @@ describe('DateInput', () => {
     expect(dayInput).toHaveFocus();
   });
 
+  function triggerKeyDown(element: HTMLElement, { key }: { key: string }) {
+    element.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true }));
+  }
+
+  function triggerKeyPress(element: HTMLElement, { key }: { key: string }) {
+    element.dispatchEvent(new KeyboardEvent('keypress', { key, bubbles: true, cancelable: true }));
+  }
+
+  function triggerKeyUp(element: HTMLElement, { key }: { key: string }) {
+    element.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true, cancelable: true }));
+  }
+
   it("jumps to the next field when a value which can't be extended to another valid value is entered by typing with multiple keys", async () => {
     function getActiveElement() {
       return document.activeElement as HTMLInputElement;
@@ -398,13 +409,13 @@ describe('DateInput', () => {
 
     function keyDown(key: string, initial = false) {
       const element = getActiveElement();
-      fireEvent.keyDown(element, { key });
-      fireEvent.keyPress(element, { key });
+      triggerKeyDown(element, { key });
+      triggerKeyPress(element, { key });
       element.value = (initial ? '' : element.value) + key;
     }
 
     function keyUp(key: string) {
-      fireEvent.keyUp(getActiveElement(), { key });
+      triggerKeyUp(getActiveElement(), { key });
     }
 
     const date = new Date(2023, 3, 1);

--- a/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
@@ -12,16 +12,16 @@ describe('DayInput', () => {
     },
   } satisfies React.ComponentProps<typeof DayInput>;
 
-  it('renders an input', () => {
-    const { container } = render(<DayInput {...defaultProps} />);
+  it('renders an input', async () => {
+    const { container } = await render(<DayInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeInTheDocument();
   });
 
-  it('renders "0" given showLeadingZeros if day is <10', () => {
-    const { container } = render(<DayInput {...defaultProps} showLeadingZeros value="9" />);
+  it('renders "0" given showLeadingZeros if day is <10', async () => {
+    const { container } = await render(<DayInput {...defaultProps} showLeadingZeros value="9" />);
 
     const input = container.querySelector('input');
 
@@ -29,8 +29,8 @@ describe('DayInput', () => {
     expect(input).toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" given showLeadingZeros if day is <10 with leading zero already', () => {
-    const { container } = render(<DayInput {...defaultProps} showLeadingZeros value="09" />);
+  it('does not render "0" given showLeadingZeros if day is <10 with leading zero already', async () => {
+    const { container } = await render(<DayInput {...defaultProps} showLeadingZeros value="09" />);
 
     const input = container.querySelector('input');
 
@@ -38,8 +38,8 @@ describe('DayInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" given showLeadingZeros if day is >=10', () => {
-    const { container } = render(<DayInput {...defaultProps} showLeadingZeros value="10" />);
+  it('does not render "0" given showLeadingZeros if day is >=10', async () => {
+    const { container } = await render(<DayInput {...defaultProps} showLeadingZeros value="10" />);
 
     const input = container.querySelector('input');
 
@@ -47,8 +47,8 @@ describe('DayInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" if not given showLeadingZeros', () => {
-    const { container } = render(<DayInput {...defaultProps} value="9" />);
+  it('does not render "0" if not given showLeadingZeros', async () => {
+    const { container } = await render(<DayInput {...defaultProps} value="9" />);
 
     const input = container.querySelector('input');
 
@@ -56,38 +56,38 @@ describe('DayInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('applies given aria-label properly', () => {
+  it('applies given aria-label properly', async () => {
     const dayAriaLabel = 'Day';
 
-    const { container } = render(<DayInput {...defaultProps} ariaLabel={dayAriaLabel} />);
+    const { container } = await render(<DayInput {...defaultProps} ariaLabel={dayAriaLabel} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('aria-label', dayAriaLabel);
   });
 
-  it('applies given placeholder properly', () => {
+  it('applies given placeholder properly', async () => {
     const dayPlaceholder = 'dd';
 
-    const { container } = render(<DayInput {...defaultProps} placeholder={dayPlaceholder} />);
+    const { container } = await render(<DayInput {...defaultProps} placeholder={dayPlaceholder} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('placeholder', dayPlaceholder);
   });
 
-  it('has proper name defined', () => {
-    const { container } = render(<DayInput {...defaultProps} />);
+  it('has proper name defined', async () => {
+    const { container } = await render(<DayInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('name', 'day');
   });
 
-  it('has proper className defined', () => {
+  it('has proper className defined', async () => {
     const className = 'react-date-picker';
 
-    const { container } = render(<DayInput {...defaultProps} className={className} />);
+    const { container } = await render(<DayInput {...defaultProps} className={className} />);
 
     const input = container.querySelector('input');
 
@@ -95,66 +95,66 @@ describe('DayInput', () => {
     expect(input).toHaveClass('react-date-picker__day');
   });
 
-  it('displays given value properly', () => {
+  it('displays given value properly', async () => {
     const value = '11';
 
-    const { container } = render(<DayInput {...defaultProps} value={value} />);
+    const { container } = await render(<DayInput {...defaultProps} value={value} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveValue(Number(value));
   });
 
-  it('does not disable input by default', () => {
-    const { container } = render(<DayInput {...defaultProps} />);
+  it('does not disable input by default', async () => {
+    const { container } = await render(<DayInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeDisabled();
   });
 
-  it('disables input given disabled flag', () => {
-    const { container } = render(<DayInput {...defaultProps} disabled />);
+  it('disables input given disabled flag', async () => {
+    const { container } = await render(<DayInput {...defaultProps} disabled />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeDisabled();
   });
 
-  it('is not required input by default', () => {
-    const { container } = render(<DayInput {...defaultProps} />);
+  it('is not required input by default', async () => {
+    const { container } = await render(<DayInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeRequired();
   });
 
-  it('required input given required flag', () => {
-    const { container } = render(<DayInput {...defaultProps} required />);
+  it('required input given required flag', async () => {
+    const { container } = await render(<DayInput {...defaultProps} required />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeRequired();
   });
 
-  it('handles inputRef properly', () => {
+  it('handles inputRef properly', async () => {
     const inputRef = createRef<HTMLInputElement>();
 
-    render(<DayInput {...defaultProps} inputRef={inputRef} />);
+    await render(<DayInput {...defaultProps} inputRef={inputRef} />);
 
     expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
   });
 
-  it('has min = "1" by default', () => {
-    const { container } = render(<DayInput {...defaultProps} />);
+  it('has min = "1" by default', async () => {
+    const { container } = await render(<DayInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('min', '1');
   });
 
-  it('has min = "1" given minDate in a past month', () => {
-    const { container } = render(
+  it('has min = "1" given minDate in a past month', async () => {
+    const { container } = await render(
       <DayInput {...defaultProps} minDate={new Date(2017, 11, 15)} month="1" year="2018" />,
     );
 
@@ -163,8 +163,8 @@ describe('DayInput', () => {
     expect(input).toHaveAttribute('min', '1');
   });
 
-  it('has min = (day in minDate) given minDate in a current month', () => {
-    const { container } = render(
+  it('has min = (day in minDate) given minDate in a current month', async () => {
+    const { container } = await render(
       <DayInput {...defaultProps} minDate={new Date(2018, 0, 15)} month="1" year="2018" />,
     );
 
@@ -173,20 +173,20 @@ describe('DayInput', () => {
     expect(input).toHaveAttribute('min', '15');
   });
 
-  it('has max = (number of days in current month) by default', () => {
+  it('has max = (number of days in current month) by default', async () => {
     const numberOfDaysInJanuary2018 = new Date(2018, 1, 0).getDate();
 
-    const { container } = render(<DayInput {...defaultProps} month="1" year="2018" />);
+    const { container } = await render(<DayInput {...defaultProps} month="1" year="2018" />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('max', `${numberOfDaysInJanuary2018}`);
   });
 
-  it('has max = (number of days in current month) given maxDate in a future month', () => {
+  it('has max = (number of days in current month) given maxDate in a future month', async () => {
     const numberOfDaysInJanuary2018 = new Date(2018, 1, 0).getDate();
 
-    const { container } = render(
+    const { container } = await render(
       <DayInput {...defaultProps} maxDate={new Date(2018, 1, 15)} month="1" year="2018" />,
     );
 
@@ -195,8 +195,8 @@ describe('DayInput', () => {
     expect(input).toHaveAttribute('max', `${numberOfDaysInJanuary2018}`);
   });
 
-  it('has max = (day in maxDate) given maxDate in a current month', () => {
-    const { container } = render(
+  it('has max = (day in maxDate) given maxDate in a current month', async () => {
+    const { container } = await render(
       <DayInput {...defaultProps} maxDate={new Date(2018, 0, 15)} month="1" year="2018" />,
     );
 

--- a/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/DayInput.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
 import { createRef } from 'react';
 
 import DayInput from './DayInput.js';

--- a/packages/react-date-picker/src/DateInput/MonthInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/MonthInput.spec.tsx
@@ -12,16 +12,16 @@ describe('MonthInput', () => {
     },
   } satisfies React.ComponentProps<typeof MonthInput>;
 
-  it('renders an input', () => {
-    const { container } = render(<MonthInput {...defaultProps} />);
+  it('renders an input', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeInTheDocument();
   });
 
-  it('renders "0" given showLeadingZeros if month is <10', () => {
-    const { container } = render(<MonthInput {...defaultProps} showLeadingZeros value="9" />);
+  it('renders "0" given showLeadingZeros if month is <10', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} showLeadingZeros value="9" />);
 
     const input = container.querySelector('input');
 
@@ -29,8 +29,10 @@ describe('MonthInput', () => {
     expect(input).toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" given showLeadingZeros if month is <10 with leading zero already', () => {
-    const { container } = render(<MonthInput {...defaultProps} showLeadingZeros value="09" />);
+  it('does not render "0" given showLeadingZeros if month is <10 with leading zero already', async () => {
+    const { container } = await render(
+      <MonthInput {...defaultProps} showLeadingZeros value="09" />,
+    );
 
     const input = container.querySelector('input');
 
@@ -38,8 +40,10 @@ describe('MonthInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" given showLeadingZeros if month is >=10', () => {
-    const { container } = render(<MonthInput {...defaultProps} showLeadingZeros value="10" />);
+  it('does not render "0" given showLeadingZeros if month is >=10', async () => {
+    const { container } = await render(
+      <MonthInput {...defaultProps} showLeadingZeros value="10" />,
+    );
 
     const input = container.querySelector('input');
 
@@ -47,8 +51,8 @@ describe('MonthInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('does not render "0" if not given showLeadingZeros', () => {
-    const { container } = render(<MonthInput {...defaultProps} value="9" />);
+  it('does not render "0" if not given showLeadingZeros', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} value="9" />);
 
     const input = container.querySelector('input');
 
@@ -56,38 +60,40 @@ describe('MonthInput', () => {
     expect(input).not.toHaveClass(`${defaultProps.className}__input--hasLeadingZero`);
   });
 
-  it('applies given aria-label properly', () => {
+  it('applies given aria-label properly', async () => {
     const monthAriaLabel = 'Month';
 
-    const { container } = render(<MonthInput {...defaultProps} ariaLabel={monthAriaLabel} />);
+    const { container } = await render(<MonthInput {...defaultProps} ariaLabel={monthAriaLabel} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('aria-label', monthAriaLabel);
   });
 
-  it('applies given placeholder properly', () => {
+  it('applies given placeholder properly', async () => {
     const monthPlaceholder = 'mm';
 
-    const { container } = render(<MonthInput {...defaultProps} placeholder={monthPlaceholder} />);
+    const { container } = await render(
+      <MonthInput {...defaultProps} placeholder={monthPlaceholder} />,
+    );
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('placeholder', monthPlaceholder);
   });
 
-  it('has proper name defined', () => {
-    const { container } = render(<MonthInput {...defaultProps} />);
+  it('has proper name defined', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('name', 'month');
   });
 
-  it('has proper className defined', () => {
+  it('has proper className defined', async () => {
     const className = 'react-date-picker';
 
-    const { container } = render(<MonthInput {...defaultProps} className={className} />);
+    const { container } = await render(<MonthInput {...defaultProps} className={className} />);
 
     const input = container.querySelector('input');
 
@@ -95,66 +101,66 @@ describe('MonthInput', () => {
     expect(input).toHaveClass('react-date-picker__month');
   });
 
-  it('displays given value properly', () => {
+  it('displays given value properly', async () => {
     const value = '11';
 
-    const { container } = render(<MonthInput {...defaultProps} value={value} />);
+    const { container } = await render(<MonthInput {...defaultProps} value={value} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveValue(Number(value));
   });
 
-  it('does not disable input by default', () => {
-    const { container } = render(<MonthInput {...defaultProps} />);
+  it('does not disable input by default', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeDisabled();
   });
 
-  it('disables input given disabled flag', () => {
-    const { container } = render(<MonthInput {...defaultProps} disabled />);
+  it('disables input given disabled flag', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} disabled />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeDisabled();
   });
 
-  it('is not required input by default', () => {
-    const { container } = render(<MonthInput {...defaultProps} />);
+  it('is not required input by default', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeRequired();
   });
 
-  it('required input given required flag', () => {
-    const { container } = render(<MonthInput {...defaultProps} required />);
+  it('required input given required flag', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} required />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeRequired();
   });
 
-  it('handles inputRef properly', () => {
+  it('handles inputRef properly', async () => {
     const inputRef = createRef<HTMLInputElement>();
 
-    render(<MonthInput {...defaultProps} inputRef={inputRef} />);
+    await render(<MonthInput {...defaultProps} inputRef={inputRef} />);
 
     expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
   });
 
-  it('has min = "1" by default', () => {
-    const { container } = render(<MonthInput {...defaultProps} />);
+  it('has min = "1" by default', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('min', '1');
   });
 
-  it('has min = "1" given minDate in a past year', () => {
-    const { container } = render(
+  it('has min = "1" given minDate in a past year', async () => {
+    const { container } = await render(
       <MonthInput {...defaultProps} minDate={new Date(2017, 6, 1)} year="2018" />,
     );
 
@@ -163,8 +169,8 @@ describe('MonthInput', () => {
     expect(input).toHaveAttribute('min', '1');
   });
 
-  it('has min = (month in minDate) given minDate in a current year', () => {
-    const { container } = render(
+  it('has min = (month in minDate) given minDate in a current year', async () => {
+    const { container } = await render(
       <MonthInput {...defaultProps} minDate={new Date(2018, 6, 1)} year="2018" />,
     );
 
@@ -173,16 +179,16 @@ describe('MonthInput', () => {
     expect(input).toHaveAttribute('min', '7');
   });
 
-  it('has max = "12" by default', () => {
-    const { container } = render(<MonthInput {...defaultProps} year="2018" />);
+  it('has max = "12" by default', async () => {
+    const { container } = await render(<MonthInput {...defaultProps} year="2018" />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('max', '12');
   });
 
-  it('has max = "12" given maxDate in a future year', () => {
-    const { container } = render(
+  it('has max = "12" given maxDate in a future year', async () => {
+    const { container } = await render(
       <MonthInput {...defaultProps} maxDate={new Date(2019, 6, 1)} year="2018" />,
     );
 
@@ -191,8 +197,8 @@ describe('MonthInput', () => {
     expect(input).toHaveAttribute('max', '12');
   });
 
-  it('has max = (month in maxDate) given maxDate in a current year', () => {
-    const { container } = render(
+  it('has max = (month in maxDate) given maxDate in a current year', async () => {
+    const { container } = await render(
       <MonthInput {...defaultProps} maxDate={new Date(2018, 6, 1)} year="2018" />,
     );
 

--- a/packages/react-date-picker/src/DateInput/MonthInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/MonthInput.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
 import { createRef } from 'react';
 
 import MonthInput from './MonthInput.js';

--- a/packages/react-date-picker/src/DateInput/MonthSelect.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/MonthSelect.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
 import { createRef } from 'react';
 
 import MonthSelect from './MonthSelect.js';

--- a/packages/react-date-picker/src/DateInput/MonthSelect.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/MonthSelect.spec.tsx
@@ -12,8 +12,8 @@ describe('MonthSelect', () => {
     },
   } satisfies React.ComponentProps<typeof MonthSelect>;
 
-  it('renders a select', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('renders a select', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const select = container.querySelector('select') as HTMLSelectElement;
     expect(select).toBeInTheDocument();
@@ -22,18 +22,20 @@ describe('MonthSelect', () => {
     expect(options).toHaveLength(13); // 12 months + empty option
   });
 
-  it('applies given aria-label properly', () => {
+  it('applies given aria-label properly', async () => {
     const monthAriaLabel = 'Month';
 
-    const { container } = render(<MonthSelect {...defaultProps} ariaLabel={monthAriaLabel} />);
+    const { container } = await render(
+      <MonthSelect {...defaultProps} ariaLabel={monthAriaLabel} />,
+    );
 
     const select = container.querySelector('select');
 
     expect(select).toHaveAttribute('aria-label', monthAriaLabel);
   });
 
-  it('has proper placeholder by default', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('has proper placeholder by default', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const options = container.querySelectorAll('option');
     const firstOption = options[0];
@@ -41,10 +43,12 @@ describe('MonthSelect', () => {
     expect(firstOption).toHaveTextContent('--');
   });
 
-  it('displays given placeholder properly', () => {
+  it('displays given placeholder properly', async () => {
     const monthPlaceholder = 'mm';
 
-    const { container } = render(<MonthSelect {...defaultProps} placeholder={monthPlaceholder} />);
+    const { container } = await render(
+      <MonthSelect {...defaultProps} placeholder={monthPlaceholder} />,
+    );
 
     const options = container.querySelectorAll('option');
     const firstOption = options[0];
@@ -52,18 +56,18 @@ describe('MonthSelect', () => {
     expect(firstOption).toHaveTextContent(monthPlaceholder);
   });
 
-  it('has proper name defined', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('has proper name defined', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const select = container.querySelector('select');
 
     expect(select).toHaveAttribute('name', 'month');
   });
 
-  it('has proper className defined', () => {
+  it('has proper className defined', async () => {
     const className = 'react-date-picker';
 
-    const { container } = render(<MonthSelect {...defaultProps} className={className} />);
+    const { container } = await render(<MonthSelect {...defaultProps} className={className} />);
 
     const select = container.querySelector('select');
 
@@ -71,58 +75,58 @@ describe('MonthSelect', () => {
     expect(select).toHaveClass('react-date-picker__month');
   });
 
-  it('displays given value properly', () => {
+  it('displays given value properly', async () => {
     const value = '11';
 
-    const { container } = render(<MonthSelect {...defaultProps} value={value} />);
+    const { container } = await render(<MonthSelect {...defaultProps} value={value} />);
 
     const select = container.querySelector('select');
 
     expect(select).toHaveValue(value);
   });
 
-  it('does not disable select by default', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('does not disable select by default', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const select = container.querySelector('select');
 
     expect(select).not.toBeDisabled();
   });
 
-  it('disables select given disabled flag', () => {
-    const { container } = render(<MonthSelect {...defaultProps} disabled />);
+  it('disables select given disabled flag', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} disabled />);
 
     const select = container.querySelector('select');
 
     expect(select).toBeDisabled();
   });
 
-  it('is not required select by default', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('is not required select by default', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const select = container.querySelector('select');
 
     expect(select).not.toBeRequired();
   });
 
-  it('required select given required flag', () => {
-    const { container } = render(<MonthSelect {...defaultProps} required />);
+  it('required select given required flag', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} required />);
 
     const select = container.querySelector('select');
 
     expect(select).toBeRequired();
   });
 
-  it('handles inputRef properly', () => {
+  it('handles inputRef properly', async () => {
     const inputRef = createRef<HTMLSelectElement>();
 
-    render(<MonthSelect {...defaultProps} inputRef={inputRef} />);
+    await render(<MonthSelect {...defaultProps} inputRef={inputRef} />);
 
     expect(inputRef.current).toBeInstanceOf(HTMLSelectElement);
   });
 
-  it('has all options enabled by default', () => {
-    const { container } = render(<MonthSelect {...defaultProps} />);
+  it('has all options enabled by default', async () => {
+    const { container } = await render(<MonthSelect {...defaultProps} />);
 
     const select = container.querySelector('select') as HTMLSelectElement;
     const options = Array.from(select.querySelectorAll('option'));
@@ -132,8 +136,8 @@ describe('MonthSelect', () => {
     }
   });
 
-  it('has all options enabled given minDate in a past year', () => {
-    const { container } = render(
+  it('has all options enabled given minDate in a past year', async () => {
+    const { container } = await render(
       <MonthSelect {...defaultProps} minDate={new Date(2017, 6, 1)} year="2018" />,
     );
 
@@ -145,8 +149,8 @@ describe('MonthSelect', () => {
     }
   });
 
-  it('has first (month in minDate) options disabled given minDate in a current year', () => {
-    const { container } = render(
+  it('has first (month in minDate) options disabled given minDate in a current year', async () => {
+    const { container } = await render(
       <MonthSelect {...defaultProps} minDate={new Date(2018, 6, 1)} year="2018" />,
     );
 
@@ -163,8 +167,8 @@ describe('MonthSelect', () => {
     }
   });
 
-  it('has all options enabled given maxDate in a future year', () => {
-    const { container } = render(
+  it('has all options enabled given maxDate in a future year', async () => {
+    const { container } = await render(
       <MonthSelect {...defaultProps} maxDate={new Date(2019, 6, 1)} year="2018" />,
     );
 
@@ -176,8 +180,8 @@ describe('MonthSelect', () => {
     }
   });
 
-  it('has last (month in maxDate) options disabled given maxDate in a current year', () => {
-    const { container } = render(
+  it('has last (month in maxDate) options disabled given maxDate in a current year', async () => {
+    const { container } = await render(
       <MonthSelect {...defaultProps} maxDate={new Date(2018, 6, 1)} year="2018" />,
     );
 

--- a/packages/react-date-picker/src/DateInput/NativeInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/NativeInput.spec.tsx
@@ -11,18 +11,18 @@ describe('NativeInput', () => {
     valueType: 'day',
   } satisfies React.ComponentProps<typeof NativeInput>;
 
-  it('renders an input', () => {
-    const { container } = render(<NativeInput {...defaultProps} />);
+  it('renders an input', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeInTheDocument();
   });
 
-  it('applies given aria-label properly', () => {
+  it('applies given aria-label properly', async () => {
     const nativeInputAriaLabel = 'Date';
 
-    const { container } = render(
+    const { container } = await render(
       <NativeInput {...defaultProps} ariaLabel={nativeInputAriaLabel} />,
     );
 
@@ -31,10 +31,10 @@ describe('NativeInput', () => {
     expect(input).toHaveAttribute('aria-label', nativeInputAriaLabel);
   });
 
-  it('has proper name defined', () => {
+  it('has proper name defined', async () => {
     const name = 'testName';
 
-    const { container } = render(<NativeInput {...defaultProps} name={name} />);
+    const { container } = await render(<NativeInput {...defaultProps} name={name} />);
 
     const input = container.querySelector('input');
 
@@ -47,52 +47,55 @@ describe('NativeInput', () => {
     ${'month'}  | ${'2019-06'}
     ${'year'}   | ${2019}
     ${'decade'} | ${2019}
-  `('displays given value properly if valueType is $valueType', ({ valueType, parsedValue }) => {
-    const value = new Date(2019, 5, 1);
+  `(
+    'displays given value properly if valueType is $valueType',
+    async ({ valueType, parsedValue }) => {
+      const value = new Date(2019, 5, 1);
 
-    const { container } = render(
-      <NativeInput {...defaultProps} value={value} valueType={valueType} />,
-    );
+      const { container } = await render(
+        <NativeInput {...defaultProps} value={value} valueType={valueType} />,
+      );
 
-    const input = container.querySelector('input');
+      const input = container.querySelector('input');
 
-    expect(input).toHaveValue(parsedValue);
-  });
+      expect(input).toHaveValue(parsedValue);
+    },
+  );
 
-  it('does not disable input by default', () => {
-    const { container } = render(<NativeInput {...defaultProps} />);
+  it('does not disable input by default', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeDisabled();
   });
 
-  it('disables input given disabled flag', () => {
-    const { container } = render(<NativeInput {...defaultProps} disabled />);
+  it('disables input given disabled flag', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} disabled />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeDisabled();
   });
 
-  it('is not required input by default', () => {
-    const { container } = render(<NativeInput {...defaultProps} />);
+  it('is not required input by default', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeRequired();
   });
 
-  it('required input given required flag', () => {
-    const { container } = render(<NativeInput {...defaultProps} required />);
+  it('required input given required flag', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} required />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeRequired();
   });
 
-  it('has no min by default', () => {
-    const { container } = render(<NativeInput {...defaultProps} />);
+  it('has no min by default', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
@@ -107,8 +110,8 @@ describe('NativeInput', () => {
     ${'decade'} | ${'2019'}
   `(
     'has proper min for minDate which is a full year if valueType is $valueType',
-    ({ valueType, parsedMin }) => {
-      const { container } = render(
+    async ({ valueType, parsedMin }) => {
+      const { container } = await render(
         <NativeInput {...defaultProps} minDate={new Date(2019, 0, 1)} valueType={valueType} />,
       );
 
@@ -126,8 +129,8 @@ describe('NativeInput', () => {
     ${'decade'} | ${'2019'}
   `(
     'has proper min for minDate which is not a full year if valueType is $valueType',
-    ({ valueType, parsedMin }) => {
-      const { container } = render(
+    async ({ valueType, parsedMin }) => {
+      const { container } = await render(
         <NativeInput {...defaultProps} minDate={new Date(2019, 5, 1)} valueType={valueType} />,
       );
 
@@ -137,8 +140,8 @@ describe('NativeInput', () => {
     },
   );
 
-  it('has no max by default', () => {
-    const { container } = render(<NativeInput {...defaultProps} />);
+  it('has no max by default', async () => {
+    const { container } = await render(<NativeInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
@@ -153,8 +156,8 @@ describe('NativeInput', () => {
     ${'decade'} | ${'2020'}
   `(
     'has proper max for maxDate which is a full year if valueType is $valueType',
-    ({ valueType, parsedMax }) => {
-      const { container } = render(
+    async ({ valueType, parsedMax }) => {
+      const { container } = await render(
         <NativeInput {...defaultProps} maxDate={new Date(2020, 0, 1)} valueType={valueType} />,
       );
 
@@ -172,8 +175,8 @@ describe('NativeInput', () => {
     ${'decade'} | ${'2020'}
   `(
     'has proper max for maxDate which is not a full year if valueType is $valueType',
-    ({ valueType, parsedMax }) => {
-      const { container } = render(
+    async ({ valueType, parsedMax }) => {
+      const { container } = await render(
         <NativeInput {...defaultProps} maxDate={new Date(2020, 5, 1)} valueType={valueType} />,
       );
 

--- a/packages/react-date-picker/src/DateInput/NativeInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/NativeInput.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
 
 import NativeInput from './NativeInput.js';
 

--- a/packages/react-date-picker/src/DateInput/YearInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/YearInput.spec.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { render } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
 import { createRef } from 'react';
 
 import YearInput from './YearInput.js';

--- a/packages/react-date-picker/src/DateInput/YearInput.spec.tsx
+++ b/packages/react-date-picker/src/DateInput/YearInput.spec.tsx
@@ -12,46 +12,48 @@ describe('YearInput', () => {
     },
   } satisfies React.ComponentProps<typeof YearInput>;
 
-  it('renders an input', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('renders an input', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeInTheDocument();
   });
 
-  it('applies given aria-label properly', () => {
+  it('applies given aria-label properly', async () => {
     const yearAriaLabel = 'Year';
 
-    const { container } = render(<YearInput {...defaultProps} ariaLabel={yearAriaLabel} />);
+    const { container } = await render(<YearInput {...defaultProps} ariaLabel={yearAriaLabel} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('aria-label', yearAriaLabel);
   });
 
-  it('applies given placeholder properly', () => {
+  it('applies given placeholder properly', async () => {
     const yearPlaceholder = 'Year';
 
-    const { container } = render(<YearInput {...defaultProps} placeholder={yearPlaceholder} />);
+    const { container } = await render(
+      <YearInput {...defaultProps} placeholder={yearPlaceholder} />,
+    );
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('placeholder', yearPlaceholder);
   });
 
-  it('has proper name defined', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('has proper name defined', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('name', 'year');
   });
 
-  it('has proper className defined', () => {
+  it('has proper className defined', async () => {
     const className = 'react-date-picker';
 
-    const { container } = render(<YearInput {...defaultProps} className={className} />);
+    const { container } = await render(<YearInput {...defaultProps} className={className} />);
 
     const input = container.querySelector('input');
 
@@ -59,82 +61,86 @@ describe('YearInput', () => {
     expect(input).toHaveClass('react-date-picker__year');
   });
 
-  it('displays given value properly', () => {
+  it('displays given value properly', async () => {
     const value = '2018';
 
-    const { container } = render(<YearInput {...defaultProps} value={value} />);
+    const { container } = await render(<YearInput {...defaultProps} value={value} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveValue(Number(value));
   });
 
-  it('does not disable input by default', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('does not disable input by default', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeDisabled();
   });
 
-  it('disables input given disabled flag', () => {
-    const { container } = render(<YearInput {...defaultProps} disabled />);
+  it('disables input given disabled flag', async () => {
+    const { container } = await render(<YearInput {...defaultProps} disabled />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeDisabled();
   });
 
-  it('is not required input by default', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('is not required input by default', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).not.toBeRequired();
   });
 
-  it('required input given required flag', () => {
-    const { container } = render(<YearInput {...defaultProps} required />);
+  it('required input given required flag', async () => {
+    const { container } = await render(<YearInput {...defaultProps} required />);
 
     const input = container.querySelector('input');
 
     expect(input).toBeRequired();
   });
 
-  it('handles inputRef properly', () => {
+  it('handles inputRef properly', async () => {
     const inputRef = createRef<HTMLInputElement>();
 
-    render(<YearInput {...defaultProps} inputRef={inputRef} />);
+    await render(<YearInput {...defaultProps} inputRef={inputRef} />);
 
     expect(inputRef.current).toBeInstanceOf(HTMLInputElement);
   });
 
-  it('has min = "1" by default', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('has min = "1" by default', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('min', '1');
   });
 
-  it('has min = (year in minDate) given minDate', () => {
-    const { container } = render(<YearInput {...defaultProps} minDate={new Date(2018, 6, 1)} />);
+  it('has min = (year in minDate) given minDate', async () => {
+    const { container } = await render(
+      <YearInput {...defaultProps} minDate={new Date(2018, 6, 1)} />,
+    );
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('min', '2018');
   });
 
-  it('has max = "275760" by default', () => {
-    const { container } = render(<YearInput {...defaultProps} />);
+  it('has max = "275760" by default', async () => {
+    const { container } = await render(<YearInput {...defaultProps} />);
 
     const input = container.querySelector('input');
 
     expect(input).toHaveAttribute('max', '275760');
   });
 
-  it('has max = (year in maxDate) given maxDate', () => {
-    const { container } = render(<YearInput {...defaultProps} maxDate={new Date(2018, 6, 1)} />);
+  it('has max = (year in maxDate) given maxDate', async () => {
+    const { container } = await render(
+      <YearInput {...defaultProps} maxDate={new Date(2018, 6, 1)} />,
+    );
 
     const input = container.querySelector('input');
 

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -322,6 +322,15 @@ describe('DatePicker', () => {
     expect(calendar2).toBeInTheDocument();
   });
 
+  function triggerFocusEvent(element: HTMLElement) {
+    element.dispatchEvent(
+      new FocusEvent('focusin', { bubbles: true, cancelable: false, composed: true }),
+    );
+    element.dispatchEvent(
+      new FocusEvent('focus', { bubbles: false, cancelable: false, composed: true }),
+    );
+  }
+
   describe('handles opening Calendar component when focusing on an input inside properly', () => {
     it('opens Calendar component when focusing on an input inside by default', async () => {
       const { container } = await render(<DatePicker />);
@@ -331,7 +340,9 @@ describe('DatePicker', () => {
 
       expect(calendar).toBeFalsy();
 
-      fireEvent.focus(input);
+      act(() => {
+        triggerFocusEvent(input);
+      });
 
       const calendar2 = container.querySelector('.react-calendar');
 
@@ -346,7 +357,9 @@ describe('DatePicker', () => {
 
       expect(calendar).toBeFalsy();
 
-      fireEvent.focus(input);
+      act(() => {
+        triggerFocusEvent(input);
+      });
 
       const calendar2 = container.querySelector('.react-calendar');
 
@@ -361,7 +374,9 @@ describe('DatePicker', () => {
 
       expect(calendar).toBeFalsy();
 
-      fireEvent.focus(input);
+      act(() => {
+        triggerFocusEvent(input);
+      });
 
       const calendar2 = container.querySelector('.react-calendar');
 
@@ -378,7 +393,7 @@ describe('DatePicker', () => {
 
       expect(calendar).toBeFalsy();
 
-      fireEvent.focus(input);
+      triggerFocusEvent(input);
 
       const calendar2 = container.querySelector('.react-calendar');
 
@@ -393,7 +408,7 @@ describe('DatePicker', () => {
       expect(calendar).toBeFalsy();
 
       const select = container.querySelector('select[name="month"]') as HTMLSelectElement;
-      fireEvent.focus(select);
+      triggerFocusEvent(select);
 
       const calendar2 = container.querySelector('.react-calendar');
 
@@ -414,7 +429,7 @@ describe('DatePicker', () => {
   it('closes Calendar component when focused outside', async () => {
     const { container } = await render(<DatePicker isOpen />);
 
-    fireEvent.focus(document.body);
+    triggerFocusEvent(document.body);
 
     await waitForElementToBeRemovedOrHidden(() =>
       container.querySelector('.react-date-picker__calendar'),
@@ -443,7 +458,7 @@ describe('DatePicker', () => {
     const dayInput = customInputs[1] as HTMLInputElement;
 
     fireEvent.blur(monthInput);
-    fireEvent.focus(dayInput);
+    triggerFocusEvent(dayInput);
 
     const calendar = container.querySelector('.react-calendar');
 

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -19,42 +19,42 @@ async function waitForElementToBeRemovedOrHidden(callback: () => HTMLElement | n
 }
 
 describe('DatePicker', () => {
-  it('passes default name to DateInput', () => {
-    const { container } = render(<DatePicker />);
+  it('passes default name to DateInput', async () => {
+    const { container } = await render(<DatePicker />);
 
     const nativeInput = container.querySelector('input[type="date"]');
 
     expect(nativeInput).toHaveAttribute('name', 'date');
   });
 
-  it('passes custom name to DateInput', () => {
+  it('passes custom name to DateInput', async () => {
     const name = 'testName';
 
-    const { container } = render(<DatePicker name={name} value={new Date(2020, 10, 11)} />);
+    const { container } = await render(<DatePicker name={name} value={new Date(2020, 10, 11)} />);
 
     const nativeInput = container.querySelector('input[type="date"]');
 
     expect(nativeInput).toHaveAttribute('name', name);
   });
 
-  it('passes autoFocus flag to DateInput', () => {
-    const { container } = render(<DatePicker autoFocus />);
+  it('passes autoFocus flag to DateInput', async () => {
+    const { container } = await render(<DatePicker autoFocus />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
 
     expect(customInputs[0]).toHaveFocus();
   });
 
-  it('passes disabled flag to DateInput', () => {
-    const { container } = render(<DatePicker disabled />);
+  it('passes disabled flag to DateInput', async () => {
+    const { container } = await render(<DatePicker disabled />);
 
     const nativeInput = container.querySelector('input[type="date"]');
 
     expect(nativeInput).toBeDisabled();
   });
 
-  it('passes format to DateInput', () => {
-    const { container } = render(<DatePicker format="yyyy" />);
+  it('passes format to DateInput', async () => {
+    const { container } = await render(<DatePicker format="yyyy" />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
 
@@ -62,7 +62,7 @@ describe('DatePicker', () => {
     expect(customInputs[0]).toHaveAttribute('name', 'year');
   });
 
-  it('passes aria-label props to DateInput', () => {
+  it('passes aria-label props to DateInput', async () => {
     const ariaLabelProps = {
       calendarAriaLabel: 'Toggle calendar',
       clearAriaLabel: 'Clear value',
@@ -72,7 +72,7 @@ describe('DatePicker', () => {
       yearAriaLabel: 'Year',
     };
 
-    const { container } = render(<DatePicker {...ariaLabelProps} />);
+    const { container } = await render(<DatePicker {...ariaLabelProps} />);
 
     const calendarButton = container.querySelector('button.react-date-picker__calendar-button');
     const clearButton = container.querySelector('button.react-date-picker__clear-button');
@@ -91,14 +91,14 @@ describe('DatePicker', () => {
     expect(yearInput).toHaveAttribute('aria-label', ariaLabelProps.yearAriaLabel);
   });
 
-  it('passes placeholder props to DateInput', () => {
+  it('passes placeholder props to DateInput', async () => {
     const placeholderProps = {
       dayPlaceholder: 'dd',
       monthPlaceholder: 'mm',
       yearPlaceholder: 'yyyy',
     };
 
-    const { container } = render(<DatePicker {...placeholderProps} />);
+    const { container } = await render(<DatePicker {...placeholderProps} />);
 
     const dayInput = container.querySelector('input[name="day"]');
     const monthInput = container.querySelector('input[name="month"]');
@@ -110,21 +110,21 @@ describe('DatePicker', () => {
   });
 
   describe('passes value to DateInput', () => {
-    it('passes single value to DateInput', () => {
+    it('passes single value to DateInput', async () => {
       const value = new Date(2019, 0, 1);
 
-      const { container } = render(<DatePicker value={value} />);
+      const { container } = await render(<DatePicker value={value} />);
 
       const nativeInput = container.querySelector('input[type="date"]');
 
       expect(nativeInput).toHaveValue('2019-01-01');
     });
 
-    it('passes the first item of an array of values to DateInput', () => {
+    it('passes the first item of an array of values to DateInput', async () => {
       const value1 = new Date(2019, 0, 1);
       const value2 = new Date(2019, 6, 1);
 
-      const { container } = render(<DatePicker value={[value1, value2]} />);
+      const { container } = await render(<DatePicker value={[value1, value2]} />);
 
       const nativeInput = container.querySelector('input[type="date"]');
 
@@ -132,28 +132,28 @@ describe('DatePicker', () => {
     });
   });
 
-  it('applies className to its wrapper when given a string', () => {
+  it('applies className to its wrapper when given a string', async () => {
     const className = 'testClassName';
 
-    const { container } = render(<DatePicker className={className} />);
+    const { container } = await render(<DatePicker className={className} />);
 
     const wrapper = container.firstElementChild;
 
     expect(wrapper).toHaveClass(className);
   });
 
-  it('applies "--open" className to its wrapper when given isOpen flag', () => {
-    const { container } = render(<DatePicker isOpen />);
+  it('applies "--open" className to its wrapper when given isOpen flag', async () => {
+    const { container } = await render(<DatePicker isOpen />);
 
     const wrapper = container.firstElementChild;
 
     expect(wrapper).toHaveClass('react-date-picker--open');
   });
 
-  it('applies calendar className to the calendar when given a string', () => {
+  it('applies calendar className to the calendar when given a string', async () => {
     const calendarClassName = 'testClassName';
 
-    const { container } = render(
+    const { container } = await render(
       <DatePicker calendarProps={{ className: calendarClassName }} isOpen />,
     );
 
@@ -162,8 +162,8 @@ describe('DatePicker', () => {
     expect(calendar).toHaveClass(calendarClassName);
   });
 
-  it('renders DateInput component', () => {
-    const { container } = render(<DatePicker />);
+  it('renders DateInput component', async () => {
+    const { container } = await render(<DatePicker />);
 
     const nativeInput = container.querySelector('input[type="date"]');
 
@@ -171,16 +171,16 @@ describe('DatePicker', () => {
   });
 
   describe('renders clear button properly', () => {
-    it('renders clear button', () => {
-      const { container } = render(<DatePicker />);
+    it('renders clear button', async () => {
+      const { container } = await render(<DatePicker />);
 
       const clearButton = container.querySelector('button.react-date-picker__clear-button');
 
       expect(clearButton).toBeInTheDocument();
     });
 
-    it('renders clear icon by default when clearIcon is not given', () => {
-      const { container } = render(<DatePicker />);
+    it('renders clear icon by default when clearIcon is not given', async () => {
+      const { container } = await render(<DatePicker />);
 
       const clearButton = container.querySelector(
         'button.react-date-picker__clear-button',
@@ -191,32 +191,32 @@ describe('DatePicker', () => {
       expect(clearIcon).toBeInTheDocument();
     });
 
-    it('renders clear icon when given clearIcon as a string', () => {
-      const { container } = render(<DatePicker clearIcon="❌" />);
+    it('renders clear icon when given clearIcon as a string', async () => {
+      const { container } = await render(<DatePicker clearIcon="❌" />);
 
       const clearButton = container.querySelector('button.react-date-picker__clear-button');
 
       expect(clearButton).toHaveTextContent('❌');
     });
 
-    it('renders clear icon when given clearIcon as a React element', () => {
+    it('renders clear icon when given clearIcon as a React element', async () => {
       function ClearIcon() {
         return <>❌</>;
       }
 
-      const { container } = render(<DatePicker clearIcon={<ClearIcon />} />);
+      const { container } = await render(<DatePicker clearIcon={<ClearIcon />} />);
 
       const clearButton = container.querySelector('button.react-date-picker__clear-button');
 
       expect(clearButton).toHaveTextContent('❌');
     });
 
-    it('renders clear icon when given clearIcon as a function', () => {
+    it('renders clear icon when given clearIcon as a function', async () => {
       function ClearIcon() {
         return <>❌</>;
       }
 
-      const { container } = render(<DatePicker clearIcon={ClearIcon} />);
+      const { container } = await render(<DatePicker clearIcon={ClearIcon} />);
 
       const clearButton = container.querySelector('button.react-date-picker__clear-button');
 
@@ -225,16 +225,16 @@ describe('DatePicker', () => {
   });
 
   describe('renders calendar button properly', () => {
-    it('renders calendar button', () => {
-      const { container } = render(<DatePicker />);
+    it('renders calendar button', async () => {
+      const { container } = await render(<DatePicker />);
 
       const calendarButton = container.querySelector('button.react-date-picker__calendar-button');
 
       expect(calendarButton).toBeInTheDocument();
     });
 
-    it('renders calendar icon by default when calendarIcon is not given', () => {
-      const { container } = render(<DatePicker />);
+    it('renders calendar icon by default when calendarIcon is not given', async () => {
+      const { container } = await render(<DatePicker />);
 
       const calendarButton = container.querySelector(
         'button.react-date-picker__calendar-button',
@@ -245,32 +245,32 @@ describe('DatePicker', () => {
       expect(calendarIcon).toBeInTheDocument();
     });
 
-    it('renders calendar icon when given calendarIcon as a string', () => {
-      const { container } = render(<DatePicker calendarIcon="📅" />);
+    it('renders calendar icon when given calendarIcon as a string', async () => {
+      const { container } = await render(<DatePicker calendarIcon="📅" />);
 
       const calendarButton = container.querySelector('button.react-date-picker__calendar-button');
 
       expect(calendarButton).toHaveTextContent('📅');
     });
 
-    it('renders calendar icon when given calendarIcon as a React element', () => {
+    it('renders calendar icon when given calendarIcon as a React element', async () => {
       function CalendarIcon() {
         return <>📅</>;
       }
 
-      const { container } = render(<DatePicker calendarIcon={<CalendarIcon />} />);
+      const { container } = await render(<DatePicker calendarIcon={<CalendarIcon />} />);
 
       const calendarButton = container.querySelector('button.react-date-picker__calendar-button');
 
       expect(calendarButton).toHaveTextContent('📅');
     });
 
-    it('renders calendar icon when given calendarIcon as a function', () => {
+    it('renders calendar icon when given calendarIcon as a function', async () => {
       function CalendarIcon() {
         return <>📅</>;
       }
 
-      const { container } = render(<DatePicker calendarIcon={CalendarIcon} />);
+      const { container } = await render(<DatePicker calendarIcon={CalendarIcon} />);
 
       const calendarButton = container.querySelector('button.react-date-picker__calendar-button');
 
@@ -278,24 +278,24 @@ describe('DatePicker', () => {
     });
   });
 
-  it('renders Calendar component when given isOpen flag', () => {
-    const { container } = render(<DatePicker isOpen />);
+  it('renders Calendar component when given isOpen flag', async () => {
+    const { container } = await render(<DatePicker isOpen />);
 
     const calendar = container.querySelector('.react-calendar');
 
     expect(calendar).toBeInTheDocument();
   });
 
-  it('does not render Calendar component when given disableCalendar & isOpen flags', () => {
-    const { container } = render(<DatePicker disableCalendar isOpen />);
+  it('does not render Calendar component when given disableCalendar & isOpen flags', async () => {
+    const { container } = await render(<DatePicker disableCalendar isOpen />);
 
     const calendar = container.querySelector('.react-calendar');
 
     expect(calendar).toBeFalsy();
   });
 
-  it('opens Calendar component when given isOpen flag by changing props', () => {
-    const { container, rerender } = render(<DatePicker />);
+  it('opens Calendar component when given isOpen flag by changing props', async () => {
+    const { container, rerender } = await render(<DatePicker />);
 
     const calendar = container.querySelector('.react-calendar');
 
@@ -308,8 +308,8 @@ describe('DatePicker', () => {
     expect(calendar2).toBeInTheDocument();
   });
 
-  it('opens Calendar component when clicking on a button', () => {
-    const { container } = render(<DatePicker />);
+  it('opens Calendar component when clicking on a button', async () => {
+    const { container } = await render(<DatePicker />);
 
     const calendar = container.querySelector('.react-calendar');
 
@@ -326,8 +326,8 @@ describe('DatePicker', () => {
   });
 
   describe('handles opening Calendar component when focusing on an input inside properly', () => {
-    it('opens Calendar component when focusing on an input inside by default', () => {
-      const { container } = render(<DatePicker />);
+    it('opens Calendar component when focusing on an input inside by default', async () => {
+      const { container } = await render(<DatePicker />);
 
       const calendar = container.querySelector('.react-calendar');
       const input = container.querySelector('input[name="day"]') as HTMLInputElement;
@@ -341,8 +341,8 @@ describe('DatePicker', () => {
       expect(calendar2).toBeInTheDocument();
     });
 
-    it('opens Calendar component when focusing on an input inside given openCalendarOnFocus = true', () => {
-      const { container } = render(<DatePicker openCalendarOnFocus />);
+    it('opens Calendar component when focusing on an input inside given openCalendarOnFocus = true', async () => {
+      const { container } = await render(<DatePicker openCalendarOnFocus />);
 
       const calendar = container.querySelector('.react-calendar');
       const input = container.querySelector('input[name="day"]') as HTMLInputElement;
@@ -356,8 +356,8 @@ describe('DatePicker', () => {
       expect(calendar2).toBeInTheDocument();
     });
 
-    it('does not open Calendar component when focusing on an input inside given openCalendarOnFocus = false', () => {
-      const { container } = render(<DatePicker openCalendarOnFocus={false} />);
+    it('does not open Calendar component when focusing on an input inside given openCalendarOnFocus = false', async () => {
+      const { container } = await render(<DatePicker openCalendarOnFocus={false} />);
 
       const calendar = container.querySelector('.react-calendar');
       const input = container.querySelector('input[name="day"]') as HTMLInputElement;
@@ -371,10 +371,10 @@ describe('DatePicker', () => {
       expect(calendar2).toBeFalsy();
     });
 
-    it('does not open Calendar when focusing on an input inside given shouldOpenCalendar function returning false', () => {
+    it('does not open Calendar when focusing on an input inside given shouldOpenCalendar function returning false', async () => {
       const shouldOpenCalendar = () => false;
 
-      const { container } = render(<DatePicker shouldOpenCalendar={shouldOpenCalendar} />);
+      const { container } = await render(<DatePicker shouldOpenCalendar={shouldOpenCalendar} />);
 
       const calendar = container.querySelector('.react-calendar');
       const input = container.querySelector('input[name="day"]') as HTMLInputElement;
@@ -388,8 +388,8 @@ describe('DatePicker', () => {
       expect(calendar2).toBeFalsy();
     });
 
-    it('does not open Calendar component when focusing on a select element', () => {
-      const { container } = render(<DatePicker format="dd.MMMM.yyyy" />);
+    it('does not open Calendar component when focusing on a select element', async () => {
+      const { container } = await render(<DatePicker format="dd.MMMM.yyyy" />);
 
       const calendar = container.querySelector('.react-calendar');
 
@@ -405,7 +405,7 @@ describe('DatePicker', () => {
   });
 
   it('closes Calendar component when clicked outside', async () => {
-    const { container } = render(<DatePicker isOpen />);
+    const { container } = await render(<DatePicker isOpen />);
 
     await userEvent.click(document.body);
 
@@ -415,7 +415,7 @@ describe('DatePicker', () => {
   });
 
   it('closes Calendar component when focused outside', async () => {
-    const { container } = render(<DatePicker isOpen />);
+    const { container } = await render(<DatePicker isOpen />);
 
     fireEvent.focus(document.body);
 
@@ -425,7 +425,7 @@ describe('DatePicker', () => {
   });
 
   it('closes Calendar component when tapped outside', async () => {
-    const { container } = render(<DatePicker isOpen />);
+    const { container } = await render(<DatePicker isOpen />);
 
     fireEvent.touchStart(document.body);
 
@@ -434,8 +434,8 @@ describe('DatePicker', () => {
     );
   });
 
-  it('does not close Calendar component when focused inside', () => {
-    const { container } = render(<DatePicker isOpen />);
+  it('does not close Calendar component when focused inside', async () => {
+    const { container } = await render(<DatePicker isOpen />);
 
     const customInputs = container.querySelectorAll('input[data-input]');
     const monthInput = customInputs[0] as HTMLInputElement;
@@ -450,7 +450,7 @@ describe('DatePicker', () => {
   });
 
   it('closes Calendar when changing value by default', async () => {
-    const { container } = render(<DatePicker isOpen />);
+    const { container } = await render(<DatePicker isOpen />);
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
@@ -464,7 +464,7 @@ describe('DatePicker', () => {
   });
 
   it('closes Calendar when changing value with prop closeCalendar = true', async () => {
-    const { container } = render(<DatePicker closeCalendar isOpen />);
+    const { container } = await render(<DatePicker closeCalendar isOpen />);
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
@@ -477,8 +477,8 @@ describe('DatePicker', () => {
     );
   });
 
-  it('does not close Calendar when changing value with prop closeCalendar = false', () => {
-    const { container } = render(<DatePicker closeCalendar={false} isOpen />);
+  it('does not close Calendar when changing value with prop closeCalendar = false', async () => {
+    const { container } = await render(<DatePicker closeCalendar={false} isOpen />);
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
@@ -491,10 +491,12 @@ describe('DatePicker', () => {
     expect(calendar).toBeInTheDocument();
   });
 
-  it('does not close Calendar when changing value with shouldCloseCalendar function returning false', () => {
+  it('does not close Calendar when changing value with shouldCloseCalendar function returning false', async () => {
     const shouldCloseCalendar = () => false;
 
-    const { container } = render(<DatePicker isOpen shouldCloseCalendar={shouldCloseCalendar} />);
+    const { container } = await render(
+      <DatePicker isOpen shouldCloseCalendar={shouldCloseCalendar} />,
+    );
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
@@ -507,8 +509,8 @@ describe('DatePicker', () => {
     expect(calendar).toBeInTheDocument();
   });
 
-  it('does not close Calendar when changing value using inputs', () => {
-    const { container } = render(<DatePicker isOpen />);
+  it('does not close Calendar when changing value using inputs', async () => {
+    const { container } = await render(<DatePicker isOpen />);
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
@@ -521,11 +523,11 @@ describe('DatePicker', () => {
     expect(calendar).toBeInTheDocument();
   });
 
-  it('calls onChange callback when changing value', () => {
+  it('calls onChange callback when changing value', async () => {
     const value = new Date(2023, 0, 31);
     const onChange = vi.fn();
 
-    const { container } = render(<DatePicker onChange={onChange} value={value} />);
+    const { container } = await render(<DatePicker onChange={onChange} value={value} />);
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
@@ -536,11 +538,13 @@ describe('DatePicker', () => {
     expect(onChange).toHaveBeenCalledWith(new Date(2023, 0, 1));
   });
 
-  it('calls onInvalidChange callback when changing value to an invalid one', () => {
+  it('calls onInvalidChange callback when changing value to an invalid one', async () => {
     const value = new Date(2023, 0, 31);
     const onInvalidChange = vi.fn();
 
-    const { container } = render(<DatePicker onInvalidChange={onInvalidChange} value={value} />);
+    const { container } = await render(
+      <DatePicker onInvalidChange={onInvalidChange} value={value} />,
+    );
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
@@ -551,10 +555,10 @@ describe('DatePicker', () => {
     expect(onInvalidChange).toHaveBeenCalled();
   });
 
-  it('clears the value when clicking on a button', () => {
+  it('clears the value when clicking on a button', async () => {
     const onChange = vi.fn();
 
-    const { container } = render(<DatePicker onChange={onChange} />);
+    const { container } = await render(<DatePicker onChange={onChange} />);
 
     const calendar = container.querySelector('.react-calendar');
 
@@ -569,10 +573,10 @@ describe('DatePicker', () => {
     expect(onChange).toHaveBeenCalledWith(null);
   });
 
-  it('calls onClick callback when clicked a page (sample of mouse events family)', () => {
+  it('calls onClick callback when clicked a page (sample of mouse events family)', async () => {
     const onClick = vi.fn();
 
-    const { container } = render(<DatePicker onClick={onClick} />);
+    const { container } = await render(<DatePicker onClick={onClick} />);
 
     const wrapper = container.firstElementChild as HTMLDivElement;
     fireEvent.click(wrapper);
@@ -580,10 +584,10 @@ describe('DatePicker', () => {
     expect(onClick).toHaveBeenCalled();
   });
 
-  it('calls onTouchStart callback when touched a page (sample of touch events family)', () => {
+  it('calls onTouchStart callback when touched a page (sample of touch events family)', async () => {
     const onTouchStart = vi.fn();
 
-    const { container } = render(<DatePicker onTouchStart={onTouchStart} />);
+    const { container } = await render(<DatePicker onTouchStart={onTouchStart} />);
 
     const wrapper = container.firstElementChild as HTMLDivElement;
     fireEvent.touchStart(wrapper);

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
-import { act, fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { act, fireEvent } from '@testing-library/react';
 
 import DatePicker from './DatePicker.js';
 
@@ -9,13 +9,9 @@ async function waitForElementToBeRemovedOrHidden(callback: () => HTMLElement | n
   const element = callback();
 
   if (element) {
-    try {
-      await waitFor(() =>
-        expect(element).toHaveAttribute('class', expect.stringContaining('--closed')),
-      );
-    } catch {
-      await waitForElementToBeRemoved(element);
-    }
+    await vi.waitFor(() =>
+      expect(element).toHaveAttribute('class', expect.stringContaining('--closed')),
+    );
   }
 }
 

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
-import { act } from '@testing-library/react';
+import { act } from 'react-dom/test-utils';
 
 import DatePicker from './DatePicker.js';
 

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-react';
-import { act, fireEvent } from '@testing-library/react';
+import { act } from '@testing-library/react';
 
 import DatePicker from './DatePicker.js';
 
@@ -455,6 +455,20 @@ describe('DatePicker', () => {
     );
   });
 
+  function triggerFocusOutEvent(element: HTMLElement) {
+    element.dispatchEvent(
+      new FocusEvent('focusout', { bubbles: true, cancelable: false, composed: true }),
+    );
+  }
+
+  function triggerBlurEvent(element: HTMLElement) {
+    triggerFocusOutEvent(element);
+
+    element.dispatchEvent(
+      new FocusEvent('blur', { bubbles: false, cancelable: false, composed: true }),
+    );
+  }
+
   it('does not close Calendar component when focused inside', async () => {
     const { container } = await render(<DatePicker isOpen />);
 
@@ -462,7 +476,7 @@ describe('DatePicker', () => {
     const monthInput = customInputs[0] as HTMLInputElement;
     const dayInput = customInputs[1] as HTMLInputElement;
 
-    fireEvent.blur(monthInput);
+    triggerBlurEvent(monthInput);
     triggerFocusEvent(dayInput);
 
     const calendar = container.querySelector('.react-calendar');

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -515,8 +515,8 @@ describe('DatePicker', () => {
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
-    act(() => {
-      fireEvent.change(dayInput, { target: { value: '1' } });
+    await act(async () => {
+      await userEvent.fill(dayInput, '1');
     });
 
     const calendar = container.querySelector('.react-calendar');
@@ -532,8 +532,8 @@ describe('DatePicker', () => {
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
-    act(() => {
-      fireEvent.change(dayInput, { target: { value: '1' } });
+    await act(async () => {
+      await userEvent.fill(dayInput, '1');
     });
 
     expect(onChange).toHaveBeenCalledWith(new Date(2023, 0, 1));
@@ -549,8 +549,8 @@ describe('DatePicker', () => {
 
     const dayInput = container.querySelector('input[name="day"]') as HTMLInputElement;
 
-    act(() => {
-      fireEvent.change(dayInput, { target: { value: '32' } });
+    await act(async () => {
+      await userEvent.fill(dayInput, '32');
     });
 
     expect(onInvalidChange).toHaveBeenCalled();

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -322,10 +322,15 @@ describe('DatePicker', () => {
     expect(calendar2).toBeInTheDocument();
   });
 
-  function triggerFocusEvent(element: HTMLElement) {
+  function triggerFocusInEvent(element: HTMLElement) {
     element.dispatchEvent(
       new FocusEvent('focusin', { bubbles: true, cancelable: false, composed: true }),
     );
+  }
+
+  function triggerFocusEvent(element: HTMLElement) {
+    triggerFocusInEvent(element);
+
     element.dispatchEvent(
       new FocusEvent('focus', { bubbles: false, cancelable: false, composed: true }),
     );

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -319,7 +319,7 @@ describe('DatePicker', () => {
     const button = container.querySelector(
       'button.react-date-picker__calendar-button',
     ) as HTMLButtonElement;
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     const calendar2 = container.querySelector('.react-calendar');
 
@@ -455,8 +455,8 @@ describe('DatePicker', () => {
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
-    act(() => {
-      fireEvent.click(firstTile);
+    await act(async () => {
+      await userEvent.click(firstTile);
     });
 
     await waitForElementToBeRemovedOrHidden(() =>
@@ -469,8 +469,8 @@ describe('DatePicker', () => {
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
-    act(() => {
-      fireEvent.click(firstTile);
+    await act(async () => {
+      await userEvent.click(firstTile);
     });
 
     await waitForElementToBeRemovedOrHidden(() =>
@@ -483,8 +483,8 @@ describe('DatePicker', () => {
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
-    act(() => {
-      fireEvent.click(firstTile);
+    await act(async () => {
+      await userEvent.click(firstTile);
     });
 
     const calendar = container.querySelector('.react-calendar');
@@ -501,8 +501,8 @@ describe('DatePicker', () => {
 
     const firstTile = container.querySelector('.react-calendar__tile') as HTMLButtonElement;
 
-    act(() => {
-      fireEvent.click(firstTile);
+    await act(async () => {
+      await userEvent.click(firstTile);
     });
 
     const calendar = container.querySelector('.react-calendar');
@@ -569,7 +569,7 @@ describe('DatePicker', () => {
       'button.react-date-picker__clear-button',
     ) as HTMLButtonElement;
 
-    fireEvent.click(button);
+    await userEvent.click(button);
 
     expect(onChange).toHaveBeenCalledWith(null);
   });
@@ -580,7 +580,7 @@ describe('DatePicker', () => {
     const { container } = await render(<DatePicker onClick={onClick} />);
 
     const wrapper = container.firstElementChild as HTMLDivElement;
-    fireEvent.click(wrapper);
+    await userEvent.click(wrapper);
 
     expect(onClick).toHaveBeenCalled();
   });

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { userEvent } from 'vitest/browser';
-import { act, fireEvent, render, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
+import { render } from 'vitest-browser-react';
+import { act, fireEvent, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 
 import DatePicker from './DatePicker.js';
 

--- a/packages/react-date-picker/src/DatePicker.spec.tsx
+++ b/packages/react-date-picker/src/DatePicker.spec.tsx
@@ -421,10 +421,14 @@ describe('DatePicker', () => {
     );
   });
 
+  function triggerTouchStart(element: HTMLElement) {
+    element.dispatchEvent(new TouchEvent('touchstart', { bubbles: true, cancelable: true }));
+  }
+
   it('closes Calendar component when tapped outside', async () => {
     const { container } = await render(<DatePicker isOpen />);
 
-    fireEvent.touchStart(document.body);
+    triggerTouchStart(document.body);
 
     await waitForElementToBeRemovedOrHidden(() =>
       container.querySelector('.react-date-picker__calendar'),
@@ -587,7 +591,8 @@ describe('DatePicker', () => {
     const { container } = await render(<DatePicker onTouchStart={onTouchStart} />);
 
     const wrapper = container.firstElementChild as HTMLDivElement;
-    fireEvent.touchStart(wrapper);
+
+    triggerTouchStart(wrapper);
 
     expect(onTouchStart).toHaveBeenCalled();
   });

--- a/packages/react-date-picker/vitest.config.ts
+++ b/packages/react-date-picker/vitest.config.ts
@@ -11,7 +11,6 @@ const config: ViteUserConfig = defineConfig({
       instances: [{ browser: 'chromium' }],
       provider: playwright(),
     },
-    setupFiles: 'vitest.setup.ts',
     watch: false,
   },
 });

--- a/packages/react-date-picker/vitest.setup.ts
+++ b/packages/react-date-picker/vitest.setup.ts
@@ -1,7 +1,0 @@
-import { afterEach } from 'vitest';
-import { cleanup } from '@testing-library/react';
-import '@testing-library/jest-dom/vitest';
-
-afterEach(() => {
-  cleanup();
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,13 +5,6 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@adobe/css-tools@npm:^4.3.1":
-  version: 4.3.2
-  resolution: "@adobe/css-tools@npm:4.3.2"
-  checksum: 10c0/296a03dd29f227c60500d2da8c7f64991fecf1d8b456ce2b4adb8cec7363d9c08b5b03f1463673fc8cbfe54b538745588e7a13c736d2dd14a80c01a20f127f39
-  languageName: node
-  linkType: hard
-
 "@ampproject/remapping@npm:^2.2.0":
   version: 2.3.0
   resolution: "@ampproject/remapping@npm:2.3.0"
@@ -22,7 +15,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.27.1":
+"@babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
   dependencies:
@@ -180,13 +173,6 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 10c0/5e67b56c39c4d03e59e03ba80692b24c5a921472079b63af711b1d250fc37c1733a17069b63537f750f3e937ec44a42b1ee6a46cd23b1a0df5163b17f741f7f2
-  languageName: node
-  linkType: hard
-
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.9.2":
-  version: 7.27.6
-  resolution: "@babel/runtime@npm:7.27.6"
-  checksum: 10c0/89726be83f356f511dcdb74d3ea4d873a5f0cf0017d4530cb53aa27380c01ca102d573eff8b8b77815e624b1f8c24e7f0311834ad4fb632c90a770fda00bd4c8
   languageName: node
   linkType: hard
 
@@ -781,79 +767,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^10.0.0":
-  version: 10.4.1
-  resolution: "@testing-library/dom@npm:10.4.1"
-  dependencies:
-    "@babel/code-frame": "npm:^7.10.4"
-    "@babel/runtime": "npm:^7.12.5"
-    "@types/aria-query": "npm:^5.0.1"
-    aria-query: "npm:5.3.0"
-    dom-accessibility-api: "npm:^0.5.9"
-    lz-string: "npm:^1.5.0"
-    picocolors: "npm:1.1.1"
-    pretty-format: "npm:^27.0.2"
-  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
-  languageName: node
-  linkType: hard
-
-"@testing-library/jest-dom@npm:^6.0.0":
-  version: 6.1.4
-  resolution: "@testing-library/jest-dom@npm:6.1.4"
-  dependencies:
-    "@adobe/css-tools": "npm:^4.3.1"
-    "@babel/runtime": "npm:^7.9.2"
-    aria-query: "npm:^5.0.0"
-    chalk: "npm:^3.0.0"
-    css.escape: "npm:^1.5.1"
-    dom-accessibility-api: "npm:^0.5.6"
-    lodash: "npm:^4.17.15"
-    redent: "npm:^3.0.0"
-  peerDependencies:
-    "@jest/globals": ">= 28"
-    "@types/jest": ">= 28"
-    jest: ">= 28"
-    vitest: ">= 0.32"
-  peerDependenciesMeta:
-    "@jest/globals":
-      optional: true
-    "@types/jest":
-      optional: true
-    jest:
-      optional: true
-    vitest:
-      optional: true
-  checksum: 10c0/2e23f120613fd8ae6d5169bbc94f1a2e4c82b07182057dc94db8ec54ebf32555833442e6c43a187e59715d83704ffb5df49ba88a71f6f32d2683f3d95ba721c7
-  languageName: node
-  linkType: hard
-
-"@testing-library/react@npm:^16.0.0":
-  version: 16.0.0
-  resolution: "@testing-library/react@npm:16.0.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-  peerDependencies:
-    "@testing-library/dom": ^10.0.0
-    "@types/react": ^18.0.0
-    "@types/react-dom": ^18.0.0
-    react: ^18.0.0
-    react-dom: ^18.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/297f97bf4722dad05f11d9cafd47d387dbdb096fea4b79b876c7466460f0f2e345b55b81b3e37fc81ed8185c528cb53dd8455ca1b6b019b229edf6c796f11c9f
-  languageName: node
-  linkType: hard
-
-"@types/aria-query@npm:^5.0.1":
-  version: 5.0.1
-  resolution: "@types/aria-query@npm:5.0.1"
-  checksum: 10c0/bc9e40ce37bd3a1654948778c7829bd55aea1bc5f2cd06fcf6cd650b07bb388995799e9aab6e2d93a6cf55dcba3b85c155f7ba93adefcc7c2e152fc6057061b5
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -1137,7 +1050,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+"ansi-styles@npm:^4.0.0":
   version: 4.3.0
   resolution: "ansi-styles@npm:4.3.0"
   dependencies:
@@ -1146,26 +1059,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:^5.0.0":
-  version: 5.2.0
-  resolution: "ansi-styles@npm:5.2.0"
-  checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
-  languageName: node
-  linkType: hard
-
 "ansi-styles@npm:^6.1.0":
   version: 6.2.1
   resolution: "ansi-styles@npm:6.2.1"
   checksum: 10c0/5d1ec38c123984bcedd996eac680d548f31828bd679a66db2bdf11844634dde55fec3efa9c6bb1d89056a5e79c1ac540c4c784d592ea1d25028a92227d2f2d5c
-  languageName: node
-  linkType: hard
-
-"aria-query@npm:5.3.0, aria-query@npm:^5.0.0":
-  version: 5.3.0
-  resolution: "aria-query@npm:5.3.0"
-  dependencies:
-    dequal: "npm:^2.0.3"
-  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
   languageName: node
   linkType: hard
 
@@ -1246,16 +1143,6 @@ __metadata:
   version: 6.2.0
   resolution: "chai@npm:6.2.0"
   checksum: 10c0/a4b7d7f5907187e09f1847afa838d6d1608adc7d822031b7900813c4ed5d9702911ac2468bf290676f22fddb3d727b1be90b57c1d0a69b902534ee29cdc6ff8a
-  languageName: node
-  linkType: hard
-
-"chalk@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "chalk@npm:3.0.0"
-  dependencies:
-    ansi-styles: "npm:^4.1.0"
-    supports-color: "npm:^7.1.0"
-  checksum: 10c0/ee650b0a065b3d7a6fda258e75d3a86fc8e4effa55871da730a9e42ccb035bf5fd203525e5a1ef45ec2582ecc4f65b47eb11357c526b84dd29a14fb162c414d2
   languageName: node
   linkType: hard
 
@@ -1355,13 +1242,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"css.escape@npm:^1.5.1":
-  version: 1.5.1
-  resolution: "css.escape@npm:1.5.1"
-  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
-  languageName: node
-  linkType: hard
-
 "csstype@npm:^3.0.2":
   version: 3.1.1
   resolution: "csstype@npm:3.1.1"
@@ -1381,13 +1261,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:^2.0.3":
-  version: 2.0.3
-  resolution: "dequal@npm:2.0.3"
-  checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
-  languageName: node
-  linkType: hard
-
 "detect-element-overflow@npm:^2.0.0":
   version: 2.0.0
   resolution: "detect-element-overflow@npm:2.0.0"
@@ -1401,13 +1274,6 @@ __metadata:
   dependencies:
     path-type: "npm:^4.0.0"
   checksum: 10c0/dcac00920a4d503e38bb64001acb19df4efc14536ada475725e12f52c16777afdee4db827f55f13a908ee7efc0cb282e2e3dbaeeb98c0993dd93d1802d3bf00c
-  languageName: node
-  linkType: hard
-
-"dom-accessibility-api@npm:^0.5.6, dom-accessibility-api@npm:^0.5.9":
-  version: 0.5.16
-  resolution: "dom-accessibility-api@npm:0.5.16"
-  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
   languageName: node
   linkType: hard
 
@@ -1759,13 +1625,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-flag@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "has-flag@npm:4.0.0"
-  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
-  languageName: node
-  linkType: hard
-
 "http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -1822,13 +1681,6 @@ __metadata:
   version: 0.1.4
   resolution: "imurmurhash@npm:0.1.4"
   checksum: 10c0/8b51313850dd33605c6c9d3fd9638b714f4c4c40250cff658209f30d40da60f78992fb2df5dabee4acf589a6a82bbc79ad5486550754bd9ec4e3fc0d4a57d6a6
-  languageName: node
-  linkType: hard
-
-"indent-string@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "indent-string@npm:4.0.0"
-  checksum: 10c0/1e1904ddb0cb3d6cce7cd09e27a90184908b7a5d5c21b92e232c93579d314f0b83c246ffb035493d0504b1e9147ba2c9b21df0030f48673fba0496ecd698161f
   languageName: node
   linkType: hard
 
@@ -1945,13 +1797,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:^4.17.15":
-  version: 4.17.21
-  resolution: "lodash@npm:4.17.21"
-  checksum: 10c0/d8cbea072bb08655bb4c989da418994b073a608dffa608b09ac04b43a791b12aeae7cd7ad919aa4c925f33b48490b5cfe6c1f71d827956071dae2e7bb3a6b74c
-  languageName: node
-  linkType: hard
-
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
@@ -1976,15 +1821,6 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
-  languageName: node
-  linkType: hard
-
-"lz-string@npm:^1.5.0":
-  version: 1.5.0
-  resolution: "lz-string@npm:1.5.0"
-  bin:
-    lz-string: bin/bin.js
-  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
   languageName: node
   linkType: hard
 
@@ -2060,13 +1896,6 @@ __metadata:
   version: 5.0.1
   resolution: "mimic-function@npm:5.0.1"
   checksum: 10c0/f3d9464dd1816ecf6bdf2aec6ba32c0728022039d992f178237d8e289b48764fee4131319e72eedd4f7f094e22ded0af836c3187a7edc4595d28dd74368fd81d
-  languageName: node
-  linkType: hard
-
-"min-indent@npm:^1.0.0":
-  version: 1.0.1
-  resolution: "min-indent@npm:1.0.1"
-  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
   languageName: node
   linkType: hard
 
@@ -2318,7 +2147,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:1.1.1, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -2392,17 +2221,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^27.0.2":
-  version: 27.5.1
-  resolution: "pretty-format@npm:27.5.1"
-  dependencies:
-    ansi-regex: "npm:^5.0.1"
-    ansi-styles: "npm:^5.0.0"
-    react-is: "npm:^17.0.1"
-  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
-  languageName: node
-  linkType: hard
-
 "proc-log@npm:^5.0.0":
   version: 5.0.0
   resolution: "proc-log@npm:5.0.0"
@@ -2459,9 +2277,6 @@ __metadata:
   resolution: "react-date-picker@workspace:packages/react-date-picker"
   dependencies:
     "@biomejs/biome": "npm:2.2.2"
-    "@testing-library/dom": "npm:^10.0.0"
-    "@testing-library/jest-dom": "npm:^6.0.0"
-    "@testing-library/react": "npm:^16.0.0"
     "@types/node": "npm:*"
     "@types/react": "npm:*"
     "@types/react-dom": "npm:*"
@@ -2519,13 +2334,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react-is@npm:17.0.2"
-  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
-  languageName: node
-  linkType: hard
-
 "react-refresh@npm:^0.17.0":
   version: 0.17.0
   resolution: "react-refresh@npm:0.17.0"
@@ -2539,16 +2347,6 @@ __metadata:
   dependencies:
     loose-envify: "npm:^1.1.0"
   checksum: 10c0/b562d9b569b0cb315e44b48099f7712283d93df36b19a39a67c254c6686479d3980b7f013dc931f4a5a3ae7645eae6386b4aa5eea933baa54ecd0f9acb0902b8
-  languageName: node
-  linkType: hard
-
-"redent@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "redent@npm:3.0.0"
-  dependencies:
-    indent-string: "npm:^4.0.0"
-    strip-indent: "npm:^3.0.0"
-  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
   languageName: node
   linkType: hard
 
@@ -2837,24 +2635,6 @@ __metadata:
   dependencies:
     ansi-regex: "npm:^6.0.1"
   checksum: 10c0/a198c3762e8832505328cbf9e8c8381de14a4fa50a4f9b2160138158ea88c0f5549fb50cb13c651c3088f47e63a108b34622ec18c0499b6c8c3a5ddf6b305ac4
-  languageName: node
-  linkType: hard
-
-"strip-indent@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "strip-indent@npm:3.0.0"
-  dependencies:
-    min-indent: "npm:^1.0.0"
-  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
-  languageName: node
-  linkType: hard
-
-"supports-color@npm:^7.1.0":
-  version: 7.2.0
-  resolution: "supports-color@npm:7.2.0"
-  dependencies:
-    has-flag: "npm:^4.0.0"
-  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **Make render function calls async**
- **Swap render function**
- **Replace fireEvent.click with userEvent.click**
- **Replace fireEvent.change with userEvent.fill**
- **Use userEvent.clear() instead of userEvent.fill with empty value**
- **Replace userEvent.key* with custom solution**
- **Remove useless Vitest setup**
- **Remove use of waitFor, waitForElementToBeRemoved**
- **Replace userEvent.touchStart with custom solution**
- **Replace userEvent.focus with custom solution**
- **Replace userEvent.focusIn with custom solution**
- **Replace userEvent.blur with custom solution**
- **Use act() from react-dom/test-utils**
- **Remove useless packages**
